### PR TITLE
Update PayPal partner attribution ID

### DIFF
--- a/includes/classes/observers/auto.paypalrestful.php
+++ b/includes/classes/observers/auto.paypalrestful.php
@@ -285,7 +285,7 @@ class zcObserverPaypalrestful
         }
 
         $js_fields['integration-date'] = '2025-08-01';
-        $js_scriptparams[] = 'data-partner-attribution-id="ZenCart_SP_PPCP"';
+        $js_scriptparams[] = 'data-partner-attribution-id="NuminixPPCP_SP"';
         $js_scriptparams[] = 'data-namespace="PayPalSDK"';
 ?>
 

--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -710,7 +710,7 @@ class PayPalRestfulApi extends ErrorInfo
             'Content-Type: application/json',
             "Authorization: Bearer $oauth2_token",
             'Prefer: return=representation',
-            'PayPal-Partner-Attribution-Id: ZenCart_SP_PPCP',
+            'PayPal-Partner-Attribution-Id: NuminixPPCP_SP',
         ];
 
         // -----


### PR DESCRIPTION
## Summary
- update the PayPal transaction header to use the NuminixPPCP_SP partner attribution id
- align the PayPal SDK script parameter with the new partner attribution id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cae2b24fa08325832253e9f50dd768