### PR TITLE
Add ObserverManager trait compatibility shim

### DIFF
--- a/admin/includes/classes/observers/auto.PaypalRestAdmin.php
+++ b/admin/includes/classes/observers/auto.PaypalRestAdmin.php
@@ -12,6 +12,9 @@ use PayPalRestful\Zc2Pp\Amount;
 use Zencart\Traits\ObserverManager;
 
 require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
+if (!trait_exists('Zencart\\Traits\\ObserverManager')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/ObserverManager.php';
+}
 
 class zcObserverPaypalRestAdmin
 {

--- a/includes/classes/observers/auto.paypalrestful.php
+++ b/includes/classes/observers/auto.paypalrestful.php
@@ -16,6 +16,9 @@ use PayPalRestful\Zc2Pp\Amount;
 use Zencart\Traits\ObserverManager;
 
 require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
+if (!trait_exists('Zencart\\Traits\\ObserverManager')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/ObserverManager.php';
+}
 
 class zcObserverPaypalrestful
 {

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/ObserverManager.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/ObserverManager.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Zencart\Traits;
+
+use Zencart\Events\EventDto;
+
+if (!trait_exists('Zencart\\Traits\\ObserverManager')) {
+    trait ObserverManager
+    {
+        /**
+         * method used to an attach an observer to the notifier object
+         *
+         * NB. We have to get a little sneaky here to stop session based classes adding events ad infinitum
+         * To do this we first concatenate the class name with the event id, as a class is only ever going to attach to an
+         * event id once, this provides a unique key. To ensure there are no naming problems with the array key, we md5 the
+         * unique name to provide a unique hashed key.
+         *
+         * @param object Reference to the observer class
+         * @param array An array of eventId's to observe
+         */
+        function attach(&$observer, $eventIDArray)
+        {
+            foreach ($eventIDArray as $eventID) {
+                $nameHash = md5(get_class($observer) . $eventID);
+                EventDto::getInstance()->setObserver($nameHash, array('obs' => &$observer, 'eventID' => $eventID));
+            }
+        }
+
+        /**
+         * method used to detach an observer from the notifier object
+         * @param object
+         * @param array
+         */
+        function detach($observer, $eventIDArray)
+        {
+            foreach ($eventIDArray as $eventID) {
+                $nameHash = md5(get_class($observer) . $eventID);
+                EventDto::getInstance()->removeObserver($nameHash);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a compatibility ObserverManager trait mirroring the Zen Cart 1.5.8 implementation
- conditionally load the compatibility shim from both storefront and admin observers so older Zen Cart releases can attach/detach observers safely

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Compatibility/ObserverManager.php
- php -l includes/classes/observers/auto.paypalrestful.php
- php -l admin/includes/classes/observers/auto.PaypalRestAdmin.php

------
https://chatgpt.com/codex/tasks/task_b_68caf6bc981483258ffd3d0dece2678a