### PR TITLE
Add compatibility language loader for paypalr

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/Language.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/Language.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Compatibility language loader for the PayPalRestful (paypalr) payment module.
+ *
+ * @copyright Copyright 2023-2025 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ *
+ * Last updated: v1.3.0
+ */
+
+namespace PayPalRestful\Compatibility;
+
+class Language
+{
+    /** @var bool */
+    protected static bool $loaded = false;
+
+    public static function load(): void
+    {
+        if (self::$loaded === true) {
+            return;
+        }
+        self::$loaded = true;
+
+        $language = self::determineLanguage();
+        foreach (self::getLanguageDirectories($language) as $languageBase) {
+            self::includeLanguageFiles($languageBase);
+        }
+    }
+
+    protected static function determineLanguage(): string
+    {
+        $fallback = 'english';
+        if (defined('IS_ADMIN_FLAG') && IS_ADMIN_FLAG === true) {
+            return $_SESSION['admin_language'] ?? $fallback;
+        }
+
+        return $_SESSION['language'] ?? $fallback;
+    }
+
+    protected static function getLanguageDirectories(string $language): array
+    {
+        $directories = [];
+        if (defined('DIR_FS_CATALOG') && defined('DIR_WS_LANGUAGES')) {
+            $directories[] = DIR_FS_CATALOG . DIR_WS_LANGUAGES . $language . '/';
+        }
+        if (defined('DIR_FS_ADMIN') && defined('DIR_WS_LANGUAGES')) {
+            $directories[] = DIR_FS_ADMIN . DIR_WS_LANGUAGES . $language . '/';
+        }
+
+        $directories = array_filter($directories, static fn ($directory) => is_dir($directory));
+
+        return array_values(array_unique($directories));
+    }
+
+    protected static function includeLanguageFiles(string $languageBase): void
+    {
+        $moduleDirectory = $languageBase . 'modules/payment/';
+        if (is_dir($moduleDirectory)) {
+            foreach (self::getModuleLanguagePaths($moduleDirectory) as $moduleFile) {
+                self::includeAndDefine($moduleFile);
+            }
+        }
+
+        $extraDefinitions = $languageBase . 'extra_definitions/';
+        if (is_dir($extraDefinitions)) {
+            foreach (self::getExtraDefinitionPaths($extraDefinitions) as $extraFile) {
+                self::includeAndDefine($extraFile);
+            }
+        }
+    }
+
+    protected static function getModuleLanguagePaths(string $directory): array
+    {
+        $paths = [];
+        $templateDirectory = self::getTemplateOverrideDirectory();
+        if ($templateDirectory !== null) {
+            $paths[] = $directory . $templateDirectory . '/lang.paypalr.php';
+        }
+        $paths[] = $directory . 'lang.paypalr.php';
+
+        return array_filter($paths, static fn ($file) => is_file($file));
+    }
+
+    protected static function getExtraDefinitionPaths(string $directory): array
+    {
+        $files = [
+            'lang.paypalr_redirect_listener_definitions.php',
+        ];
+
+        $paths = [];
+        foreach ($files as $filename) {
+            $paths[] = $directory . $filename;
+        }
+
+        return array_filter($paths, static fn ($file) => is_file($file));
+    }
+
+    protected static function includeAndDefine(string $file): void
+    {
+        $definitions = include $file;
+        if (is_array($definitions)) {
+            foreach ($definitions as $constant => $value) {
+                if (!defined($constant)) {
+                    define($constant, $value);
+                }
+            }
+        }
+    }
+
+    protected static function getTemplateOverrideDirectory(): ?string
+    {
+        $templateDirectory = null;
+        if (defined('DIR_WS_TEMPLATE')) {
+            $templateDirectory = basename(rtrim(DIR_WS_TEMPLATE, '/'));
+        } elseif (defined('TEMPLATE_DIR')) {
+            $templateDirectory = basename((string)TEMPLATE_DIR);
+        } elseif (!empty($_SESSION['tplDir'])) {
+            $templateDirectory = basename((string)$_SESSION['tplDir']);
+        }
+
+        if ($templateDirectory === null || $templateDirectory === '' || $templateDirectory === '.' || $templateDirectory === '..') {
+            return null;
+        }
+
+        return $templateDirectory;
+    }
+}

--- a/includes/modules/payment/paypal/PayPalRestful/ppr_listener.php
+++ b/includes/modules/payment/paypal/PayPalRestful/ppr_listener.php
@@ -25,6 +25,9 @@ require DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Common\Logger;
+use PayPalRestful\Compatibility\Language as LanguageCompatibility;
+
+LanguageCompatibility::load();
 
 $op = $_GET['op'] ?? '';
 $logger = new Logger();

--- a/includes/modules/payment/paypal/pprAutoload.php
+++ b/includes/modules/payment/paypal/pprAutoload.php
@@ -11,6 +11,7 @@
 global $psr4Autoloader;
 $psr4Autoloader->addPrefix('PayPalRestful\Admin', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Admin');
 $psr4Autoloader->addPrefix('PayPalRestful\Admin\Formatters', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Admin/Formatters');
+$psr4Autoloader->addPrefix('PayPalRestful\Compatibility', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility');
 $psr4Autoloader->addPrefix('PayPalRestful\Api', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Api');
 $psr4Autoloader->addPrefix('PayPalRestful\Api\Data', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Api/Data');
 $psr4Autoloader->addPrefix('PayPalRestful\Common', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Common');

--- a/includes/modules/payment/paypalr.php
+++ b/includes/modules/payment/paypalr.php
@@ -24,9 +24,12 @@ use PayPalRestful\Api\Data\CountryCodes;
 use PayPalRestful\Common\ErrorInfo;
 use PayPalRestful\Common\Helpers;
 use PayPalRestful\Common\Logger;
+use PayPalRestful\Compatibility\Language as LanguageCompatibility;
 use PayPalRestful\Zc2Pp\Amount;
 use PayPalRestful\Zc2Pp\ConfirmPayPalPaymentChoiceRequest;
 use PayPalRestful\Zc2Pp\CreatePayPalOrderRequest;
+
+LanguageCompatibility::load();
 
 /**
  * The PayPal payment module using PayPal's RESTful API (v2)


### PR DESCRIPTION
## Summary
- add a compatibility helper to load paypalr language and extra-definition files only once
- register the helper with the module's autoloader and invoke it from the main module and listener entry point

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Compatibility/Language.php
- php -l includes/modules/payment/paypalr.php
- php -l includes/modules/payment/paypal/PayPalRestful/ppr_listener.php

------
https://chatgpt.com/codex/tasks/task_b_68caf6c7b5d483258c67126da67eba9a