### PR TITLE
Fix PHP syntax compatibility for updatePackageTracking

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -363,7 +363,7 @@ class PayPalRestfulApi extends ErrorInfo
         string $tracking_number,
         string $carrier_code,
         string $action = 'ADD',
-        bool $email_buyer = false,
+        bool $email_buyer = false
     ): false|array {
         $this->log->write("==> Start updatePackageTracking($paypal_txnid, " . Logger::logJSON($tracking_number) . ", $carrier_code, $action ...)\n", true);
 


### PR DESCRIPTION
## Summary
- remove the trailing comma from updatePackageTracking's parameter list to restore compatibility with older PHP parsers

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php

------
https://chatgpt.com/codex/tasks/task_b_68cc2ff3cbec8325ac00efca6adab105