### PR TITLE
Fix PHP 7 compatibility in updatePackageTracking

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -364,7 +364,7 @@ class PayPalRestfulApi extends ErrorInfo
         string $carrier_code,
         string $action = 'ADD',
         bool $email_buyer = false
-    ): false|array {
+    ) {
         $this->log->write("==> Start updatePackageTracking($paypal_txnid, " . Logger::logJSON($tracking_number) . ", $carrier_code, $action ...)\n", true);
 
         if (empty($tracking_number)) {


### PR DESCRIPTION
## Summary
- remove the PHP 8 union return type from `updatePackageTracking` to restore compatibility with PHP 7 runtimes

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php

------
https://chatgpt.com/codex/tasks/task_b_68cc310789748325a85c10c31224b4c4