### PR TITLE
Restore PHP 7.4 compatibility for webhook handlers

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -585,7 +585,7 @@ class PayPalRestfulApi extends ErrorInfo
         $response = $this->curlPatch("v1/notifications/webhooks/$webhook_id", [$parameters]);
     }
 
-    public function webhookVerifyByPostback($parameters): bool|null
+    public function webhookVerifyByPostback($parameters): ?bool
     {
         $this->log->write("==> Start webhookVerifyByPostback", true);
         $response = $this->curlPost('v1/notifications/verify-webhook-signature', $parameters);

--- a/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookController.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookController.php
@@ -21,7 +21,7 @@ class WebhookController
     protected bool $enableDebugFileLogging = true;
     protected Logger $ppr_logger;
 
-    public function __invoke(): bool|null
+    public function __invoke(): ?bool
     {
         defined('TABLE_PAYPAL_WEBHOOKS') or define('TABLE_PAYPAL_WEBHOOKS', DB_PREFIX . 'paypal_webhooks');
 
@@ -118,7 +118,10 @@ class WebhookController
     /**
      * Save webhook records to database for subsequent querying
      */
-    protected function saveToDatabase(string $user_agent, string $request_method, string $request_body, string|array $request_headers): void
+    /**
+     * @param array|string|null $request_headers
+     */
+    protected function saveToDatabase(string $user_agent, string $request_method, string $request_body, $request_headers): void
     {
         $json_body = json_decode($request_body, true);
 

--- a/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php
@@ -19,9 +19,12 @@ class WebhookResponder
 {
     protected bool $shouldRespond = false;
 
-    protected string|null $webhook_listener_subscribe_id = null;
+    protected ?string $webhook_listener_subscribe_id = null;
 
-    public function __construct(protected WebhookObject $webhook) {
+    protected WebhookObject $webhook;
+
+    public function __construct(WebhookObject $webhook) {
+        $this->webhook = $webhook;
         $this->setWebhookSubscribeId();
     }
 
@@ -44,7 +47,7 @@ class WebhookResponder
         return $this->shouldRespond;
     }
 
-    public function verify(): bool|null
+    public function verify(): ?bool
     {
         if ($this->shouldRespond !== true) {
             return null;
@@ -72,7 +75,7 @@ class WebhookResponder
     /**
      * @return bool|null  returns null if we cannot do CRC check, so fails over to PostBack approach
      */
-    protected function doCrcCheck(): bool|null
+    protected function doCrcCheck(): ?bool
     {
         $headers = array_change_key_case($this->webhook->getHeaders(), CASE_UPPER);
 
@@ -97,7 +100,7 @@ class WebhookResponder
     /**
      * @return bool|null  returns null if unable to use CURL or if the access token is invalid.
      */
-    protected function verifyByPostback(): bool|null
+    protected function verifyByPostback(): ?bool
     {
         $headers = array_change_key_case($this->webhook->getHeaders(), CASE_UPPER);
         $params_array = [


### PR DESCRIPTION
## Summary
- replace PHP 8 union return types with nullable bool declarations to satisfy PHP 7.4
- remove constructor property promotion and union parameter hints so webhook responder/controller load in PHP 7.4

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
- php -l includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookController.php
- php -l includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php

------
https://chatgpt.com/codex/tasks/task_b_68cc338730708325b172b7d4c1d34fae