### PR TITLE
Restore PHP 7.4 compatibility for PayPal REST module

### DIFF
--- a/includes/classes/observers/auto.paypalrestful.php
+++ b/includes/classes/observers/auto.paypalrestful.php
@@ -371,17 +371,44 @@ let paypalMessageableStyles = <?= !empty($messageStyles) ? json_encode($messageS
         $limit = defined('MODULE_PAYMENT_PAYPALR_PAYLATER_MESSAGING') ? MODULE_PAYMENT_PAYPALR_PAYLATER_MESSAGING : 'All';
         $limit = explode(', ', $limit);
 
-        return match(true) {
-            !empty(array_intersect($limit, ['All', 'Checkout'])) && str_starts_with($current_page_base, "checkout") => 'checkout',
-            !empty(array_intersect($limit, ['All', 'Shopping Cart'])) && $current_page_base === 'shopping_cart' => 'cart',
-            //!empty(array_intersect($limit, ['All', 'Shopping Cart'])) && $current_page_base === 'mini-cart' => 'mini-cart', // @TODO this is more for a header box
-            !empty(array_intersect($limit, ['All', 'Product Pages'])) && in_array($current_page_base, zen_get_buyable_product_type_handlers(), true) => 'product-details',
-            !empty(array_intersect($limit, ['All', 'Product Listings and Search Results'])) && ($category_depth === 'products' || ($tpl_page_body ?? null) === 'tpl_index_product_list.php') => 'product-listing',
-            !empty(array_intersect($limit, ['All', 'Product Listings and Search Results'])) && str_ends_with($current_page_base, 'search_result') => 'search-results',
-            !empty($limit) && $this_is_home_page => 'home',
-            !empty($limit) => 'other',
-            default => 'None',
-        };
+        $limitAllCheckout = !empty(array_intersect($limit, ['All', 'Checkout']));
+        if ($limitAllCheckout && strpos((string)$current_page_base, 'checkout') === 0) {
+            return 'checkout';
+        }
+
+        if (!empty(array_intersect($limit, ['All', 'Shopping Cart'])) && $current_page_base === 'shopping_cart') {
+            return 'cart';
+        }
+
+        //if (!empty(array_intersect($limit, ['All', 'Shopping Cart'])) && $current_page_base === 'mini-cart') {
+        //    return 'mini-cart'; // @TODO this is more for a header box
+        //}
+
+        if (!empty(array_intersect($limit, ['All', 'Product Pages'])) && in_array($current_page_base, zen_get_buyable_product_type_handlers(), true)) {
+            return 'product-details';
+        }
+
+        if (!empty(array_intersect($limit, ['All', 'Product Listings and Search Results']))
+            && ($category_depth === 'products' || ($tpl_page_body ?? null) === 'tpl_index_product_list.php')
+        ) {
+            return 'product-listing';
+        }
+
+        if (!empty(array_intersect($limit, ['All', 'Product Listings and Search Results']))
+            && substr((string)$current_page_base, -strlen('search_result')) === 'search_result'
+        ) {
+            return 'search-results';
+        }
+
+        if (!empty($limit) && $this_is_home_page) {
+            return 'home';
+        }
+
+        if (!empty($limit)) {
+            return 'other';
+        }
+
+        return 'None';
     }
 }
 

--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -429,7 +429,7 @@ class PayPalRestfulApi extends ErrorInfo
                 return false;
             }
             foreach ($trackers as $tracker) {
-                if (\str_ends_with($tracker['id'], $tracking_number)) {
+                if ($this->stringEndsWith($tracker['id'], $tracking_number)) {
                     if ($tracker['status'] === 'CANCELLED') {
                         $this->log->write("Tracker ALREADY CANCELLED for tracking_number $tracking_number; nothing to update/cancel. Txn ID: $paypal_txnid");
                         return false;
@@ -465,12 +465,12 @@ class PayPalRestfulApi extends ErrorInfo
         // skip unreachable localhost/testing domains
         $domain = str_replace(['http'.'://', 'https'.'://'], '', rtrim(HTTP_SERVER, '/'));
         foreach (['.local', '.test'] as $val) {
-            if (str_ends_with($domain, $val)) {
+            if ($this->stringEndsWith($domain, $val)) {
                 return;
             }
         }
         foreach (['localhost', '127.0.0.1'] as $val) {
-            if (str_starts_with($domain, $val)) {
+            if ($this->stringStartsWith($domain, $val)) {
                 return;
             }
         }
@@ -541,12 +541,12 @@ class PayPalRestfulApi extends ErrorInfo
         // skip unreachable localhost/testing domains
         $domain = str_replace(['http'.'://', 'https'.'://'], '', rtrim(HTTP_SERVER, '/'));
         foreach (['.local', '.test'] as $val) {
-            if (str_ends_with($domain, $val)) {
+            if ($this->stringEndsWith($domain, $val)) {
                 return;
             }
         }
         foreach (['localhost', '127.0.0.1'] as $val) {
-            if (str_starts_with($domain, $val)) {
+            if ($this->stringStartsWith($domain, $val)) {
                 return;
             }
         }
@@ -1034,4 +1034,36 @@ class PayPalRestfulApi extends ErrorInfo
         return false;
     }
     // ===== End CURL Interface Methods =====
+
+    /**
+     * Polyfill for PHP < 8.0 str_starts_with().
+     */
+    private function stringStartsWith($haystack, $needle): bool
+    {
+        $haystack = (string)$haystack;
+        $needle = (string)$needle;
+
+        if ($needle === '') {
+            return true;
+        }
+
+        return strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+
+    /**
+     * Polyfill for PHP < 8.0 str_ends_with().
+     */
+    private function stringEndsWith($haystack, $needle): bool
+    {
+        $haystack = (string)$haystack;
+        $needle = (string)$needle;
+
+        if ($needle === '') {
+            return true;
+        }
+
+        $length = strlen($needle);
+
+        return substr($haystack, -$length) === $needle;
+    }
 }

--- a/includes/modules/payment/paypal/PayPalRestful/Common/Logger.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Common/Logger.php
@@ -37,7 +37,7 @@ class Logger
             return;
         }
         
-        if (!empty($current_page_base) && \str_contains($current_page_base, 'webhook')) {
+        if (!empty($current_page_base) && strpos((string)$current_page_base, 'webhook') !== false) {
             $logfile_suffix = 'webhook-' . $uniqueName;
             $logfile_suffix = trim($logfile_suffix, '-');
         } elseif (IS_ADMIN_FLAG === false) {

--- a/includes/modules/payment/paypal/PayPalRestful/Common/PayPalShippingCarriers.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Common/PayPalShippingCarriers.php
@@ -54,7 +54,7 @@ class PayPalShippingCarriers
         // find longest-matching name
         foreach ($carriersForCountry as $code => $name) {
             $name = \strtoupper($name);
-            if (str_contains($carrier_name, $name)) {
+            if ($name === '' || strpos($carrier_name, $name) !== false) {
                 if (strlen($name) > strlen($bestMatch)) {
                     $bestMatch = $name;
                 }

--- a/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php
@@ -39,7 +39,7 @@ class WebhookResponder
         if (array_key_exists('PAYPAL-AUTH-VERSION', $headers)
             && array_key_exists('PAYPAL-AUTH-ALGO', $headers)
             && isset($data['event_type'])
-            && \str_contains($this->webhook->getUserAgent(), 'PayPal/')
+            && strpos((string)$this->webhook->getUserAgent(), 'PayPal/') !== false
         ) {
             $this->shouldRespond = true;
         }


### PR DESCRIPTION
## Summary
- replace the PayPal Pay Later messaging page-type match expression with PHP 7.4 compatible control flow
- add internal helpers for starts-with/ends-with checks and reuse them instead of PHP 8 string helpers
- swap remaining str_contains usages for strpos-based checks to avoid PHP 8 dependencies

## Testing
- php -l includes/classes/observers/auto.paypalrestful.php
- php -l includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
- php -l includes/modules/payment/paypal/PayPalRestful/Common/Logger.php
- php -l includes/modules/payment/paypal/PayPalRestful/Common/PayPalShippingCarriers.php
- php -l includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php

------
https://chatgpt.com/codex/tasks/task_b_68cc4070c9e0832595da203b2a2a5ebc