### PR TITLE
Ensure PayPal listener URLs preserve zenid in redirects

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/ConfirmPayPalPaymentChoiceRequest.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/ConfirmPayPalPaymentChoiceRequest.php
@@ -29,7 +29,7 @@ class ConfirmPayPalPaymentChoiceRequest
     // -----
     // Constructor.  Creates the payload for a PayPal payment-choice confirmation request.
     //
-    public function __construct(string $listener_endpoint, \order $order)
+    public function __construct(string $return_url, string $cancel_url, \order $order)
     {
         // -----
         // Determine the shipping-preference, one of:
@@ -76,8 +76,8 @@ class ConfirmPayPalPaymentChoiceRequest
                     'landing_page' => 'NO_PREFERENCE',  //- LOGIN, GUEST_CHECKOUT or NO_PREFERENCE
                     'shipping_preference' => $shipping_preference,    //- GET_FROM_FILE (allows shipping address change on PayPal), NO_SHIPPING, SET_PROVIDED_ADDRESS (customer can't change)
                     'user_action' => $this->userAction,  //- PAY_NOW or CONTINUE
-                    'return_url' => $listener_endpoint . '?op=return',
-                    'cancel_url' => $listener_endpoint . '?op=cancel',
+                    'return_url' => $return_url,
+                    'cancel_url' => $cancel_url,
                 ],
             ],
         ];

--- a/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/CreatePayPalOrderRequest.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/CreatePayPalOrderRequest.php
@@ -474,6 +474,9 @@ class CreatePayPalOrderRequest extends ErrorInfo
 
     protected function buildCardPaymentSource(\order $order, array $cc_info): array
     {
+        $return_url = $cc_info['redirect_urls']['3ds_return'] ?? $this->buildListenerRedirect($cc_info['redirect'] ?? '', '3ds_return');
+        $cancel_url = $cc_info['redirect_urls']['3ds_cancel'] ?? $this->buildListenerRedirect($cc_info['redirect'] ?? '', '3ds_cancel');
+
         $payment_source = [
             'name' => $cc_info['name'],
             'number' => $cc_info['number'],
@@ -481,14 +484,24 @@ class CreatePayPalOrderRequest extends ErrorInfo
             'expiry' => $cc_info['expiry_year'] . '-' . $cc_info['expiry_month'],
             'billing_address' => Address::get($order->billing),
             'experience_context' => [
-                'return_url' => $cc_info['redirect'] . '?op=3ds_return',
-                'cancel_url' => $cc_info['redirect'] . '?op=3ds_cancel',
+                'return_url' => $return_url,
+                'cancel_url' => $cancel_url,
             ],
         ];
         if (isset($_POST['ppr_cc_sca_always']) || (defined('MODULE_PAYMENT_PAYPALR_SCA_ALWAYS') && MODULE_PAYMENT_PAYPALR_SCA_ALWAYS === 'true')) {
             $payment_source['attributes']['verification']['method'] = 'SCA_ALWAYS'; //- Defaults to 'SCA_WHEN_REQUIRED' for live environment
         }
         return $payment_source;
+    }
+
+    protected function buildListenerRedirect(string $base_url, string $operation): string
+    {
+        if ($base_url === '') {
+            return '';
+        }
+
+        $separator = (strpos($base_url, '?') === false) ? '?' : '&';
+        return $base_url . $separator . 'op=' . $operation;
     }
 
     protected function buildLevel2Level3Data(array $purchase_unit): array


### PR DESCRIPTION
## Summary
- generate PayPal listener URLs with `zen_href_link` so session identifiers are retained when required
- update the confirm-payment payload builder to accept fully-formed return and cancel URLs
- adjust 3DS experience-context creation to append operations without clobbering existing query strings

## Testing
- php -l includes/modules/payment/paypalr.php
- php -l includes/modules/payment/paypal/PayPalRestful/Zc2Pp/ConfirmPayPalPaymentChoiceRequest.php
- php -l includes/modules/payment/paypal/PayPalRestful/Zc2Pp/CreatePayPalOrderRequest.php


------
https://chatgpt.com/codex/tasks/task_b_68cc5d8a361083258a44523f893d9041