### PR TITLE
Fix namespace call to zen_define_default

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/MainDisplay.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/MainDisplay.php
@@ -731,7 +731,7 @@ class MainDisplay
 
     protected function createModalButtons(string $submit_button_id, string $toggle_button_name, string $submit_button_name): string
     {
-        zen_define_default('TEXT_PLEASE_WAIT', 'Please wait ...');
+        \zen_define_default('TEXT_PLEASE_WAIT', 'Please wait ...');
         return
             '<div class="btn-group btn-group-justified ppr-button-row">
                 <div class="btn-group">


### PR DESCRIPTION
## Summary
- ensure the TEXT_PLEASE_WAIT language constant is defined when rendering admin modals by calling the Zen Cart helper from the global namespace

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/MainDisplay.php

------
https://chatgpt.com/codex/tasks/task_b_68cc7b1cea948325b995f2218167546a