### PR TITLE
Fallback define TEXT_PLEASE_WAIT when helper unavailable

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/MainDisplay.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/MainDisplay.php
@@ -731,7 +731,11 @@ class MainDisplay
 
     protected function createModalButtons(string $submit_button_id, string $toggle_button_name, string $submit_button_name): string
     {
-        zen_define_default('TEXT_PLEASE_WAIT', 'Please wait ...');
+        if (function_exists('zen_define_default')) {
+            \zen_define_default('TEXT_PLEASE_WAIT', 'Please wait ...');
+        } elseif (!defined('TEXT_PLEASE_WAIT')) {
+            define('TEXT_PLEASE_WAIT', 'Please wait ...');
+        }
         return
             '<div class="btn-group btn-group-justified ppr-button-row">
                 <div class="btn-group">


### PR DESCRIPTION
## Summary
- ensure the modal button helper defines TEXT_PLEASE_WAIT via zen_define_default when available
- provide a fallback definition when the Zen Cart helper function is missing so the admin modals still work

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/MainDisplay.php

------
https://chatgpt.com/codex/tasks/task_b_68cc7b1cea948325b995f2218167546a