### PR TITLE
Add integrated signup CTA for PayPal RESTful admin

### DIFF
--- a/includes/languages/english/modules/payment/lang.paypalr.php
+++ b/includes/languages/english/modules/payment/lang.paypalr.php
@@ -305,8 +305,13 @@ $define = [
 ];
 
 if (IS_ADMIN_FLAG === true) {
+    $define['MODULE_PAYMENT_PAYPALR_TEXT_ADMIN_ISU_INTRO'] = 'Get started with the PayPal Checkout (RESTful) integrated sign-up experience to quickly connect your store to PayPal.';
+    $define['MODULE_PAYMENT_PAYPALR_TEXT_ADMIN_ISU_BUTTON'] = 'Complete PayPal setup';
+
     $define['MODULE_PAYMENT_PAYPALR_TEXT_ADMIN_DESCRIPTION'] =
         '<b>PayPal Checkout (RESTful)</b>, v%s<br><br>' .   //- %s is filled in with the current module version
+        '<p>' . $define['MODULE_PAYMENT_PAYPALR_TEXT_ADMIN_ISU_INTRO'] . '</p>' .
+        '<p><a class="paypalr-isu-button" data-partner-attribution-id="NuminixPPCP_SP" href="' . zen_href_link('paypalr_integrated_signup.php', 'action=start', 'SSL') . '" rel="noopener noreferrer" target="_blank">' . $define['MODULE_PAYMENT_PAYPALR_TEXT_ADMIN_ISU_BUTTON'] . '</a></p>' .
         '<a href="https://www.paypal.com/login" rel="noopener noreferrer" target="_blank">Manage your PayPal <b>business</b> account</a><br><br>' .
         '<b>Configuration instructions:</b><br>' .
         '<ol>

--- a/includes/modules/payment/paypal/PayPalRestful/paypalr.admin.css
+++ b/includes/modules/payment/paypal/PayPalRestful/paypalr.admin.css
@@ -36,3 +36,20 @@ tr.ppr-payments {
     content: "\a";
     white-space: pre;
 }
+
+.paypalr-isu-button {
+    display: inline-block;
+    padding: 0.4em 0.9em;
+    background-color: #2a7abd;
+    border: 1px solid #1e5f97;
+    border-radius: 3px;
+    color: #fff !important;
+    text-decoration: none;
+}
+
+.paypalr-isu-button:focus,
+.paypalr-isu-button:hover {
+    background-color: #1e5f97;
+    border-color: #184e7d;
+    color: #fff !important;
+}


### PR DESCRIPTION
## Summary
- add language strings for the PayPal Checkout (RESTful) integrated sign-up call-to-action and surface them in the admin description ahead of the setup checklist
- style the new integrated sign-up link to match admin button treatments

## Testing
- php -l includes/languages/english/modules/payment/lang.paypalr.php

------
https://chatgpt.com/codex/tasks/task_b_68cc8b9f7ff083259884ac395dd3ef1f