### PR TITLE
Document vault usage for custom integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,58 @@ The module's operation has been validated …
 4. With both the built-in responsive_classic and [ZCA Bootstrap](https://www.zen-cart.com/downloads.php?do=file&id=2191) (v3.6.2-3.7.7) templates.
 
 For additional information, refer to the payment-module's [wiki articles](https://github.com/lat9/paypalr/wiki).
+
+## Charging vaulted cards from custom code
+
+When a customer pays by card, PayPal returns a `payment_source.card` element that includes the vaulted token. The module saves that response in the vault table via `PayPalRestful\Common\VaultManager::saveVaultedCard` and raises the `NOTIFY_PAYPALR_VAULT_CARD_SAVED` observer event so other plugins can react to the new or updated token.【F:includes/modules/payment/paypal/PayPalRestful/Common/VaultManager.php†L63-L151】【F:includes/modules/payment/paypalr.php†L2052-L2141】
+
+Third-party integrations can use the stored information to perform subsequent charges (for example, recurring subscriptions) without asking the customer to re-enter their card details:
+
+1. Include the payment module's autoloader before referencing any of its classes:
+
+   ```php
+   require_once DIR_FS_CATALOG . 'includes/modules/payment/paypal/pprAutoload.php';
+   ```
+
+2. Retrieve the customer's vaulted cards. The helper `paypalr::getVaultedCardsForCustomer($customers_id, $activeOnly = true)` returns an array of normalized records (vault identifier, status, masked digits, expiry, billing address, and the original `payment_source.card` payload). You can also call `PayPalRestful\Common\VaultManager::getCustomerVaultedCards` directly if you prefer.【F:includes/modules/payment/paypalr.php†L2559-L2561】【F:includes/modules/payment/paypal/PayPalRestful/Common/VaultManager.php†L168-L283】
+
+3. Build a new PayPal order with the vaulted instrument. Instantiate `PayPalRestful\Api\PayPalRestfulApi` using the environment credentials returned by `paypalr::getEnvironmentInfo()`, create an order payload that references the stored `vault_id`, and then authorize or capture the order. A minimal example that immediately captures a payment looks like:
+
+   ```php
+   [$clientId, $clientSecret] = paypalr::getEnvironmentInfo();
+   $api = new \PayPalRestful\Api\PayPalRestfulApi(MODULE_PAYMENT_PAYPALR_SERVER, $clientId, $clientSecret);
+
+   $card = $vaultCards[0]; // Result from step 2
+
+   $orderRequest = [
+       'intent' => 'CAPTURE',
+       'purchase_units' => [[
+           'amount' => [
+               'currency_code' => 'USD',
+               'value' => '10.00',
+           ],
+       ]],
+       'payment_source' => [
+           'card' => [
+               'vault_id' => $card['vault_id'],
+               'expiry' => $card['expiry'],
+               'last_digits' => $card['last_digits'],
+               'billing_address' => $card['billing_address'],
+               'attributes' => [
+                   'stored_credential' => [
+                       'payment_initiator' => 'MERCHANT',
+                       'payment_type' => 'RECURRING',
+                       'usage' => 'SUBSEQUENT',
+                   ],
+               ],
+           ],
+       ],
+   ];
+
+   $createResponse = $api->createOrder($orderRequest);
+   $captureResponse = $api->captureOrder($createResponse['id']);
+   ```
+
+   Adjust the purchase units, intent, and stored credential attributes to match your billing use case. PayPal's [vault documentation](https://developer.paypal.com/docs/multiparty/seller/checkout/facilitator/vault/) describes additional optional fields such as previous network transaction references.
+
+4. After PayPal returns the new capture or authorization, call `VaultManager::saveVaultedCard` with the updated `payment_source.card` element so the module records the `last_used` timestamp and any status changes for future reuse.【F:includes/modules/payment/paypal/PayPalRestful/Common/VaultManager.php†L63-L151】

--- a/readme_paypalr.html
+++ b/readme_paypalr.html
@@ -118,6 +118,56 @@ table table {
     <p>For additional information, refer to the payment-module's <a href="https://github.com/lat9/paypalr/wiki" target="_blank">wiki articles</a>.</p>
     <p><b>Credits:</b> CSS-based spinner compliments of <a href="https://loading.io/css/" target="_blank">loading.io css spinner</a>.</p>
 
+    <h2>Charging vaulted cards from custom code</h2>
+    <p>When the checkout flow completes a card payment, PayPal returns a <code>payment_source.card</code> payload that contains the vault token. The module saves that response via <code>PayPalRestful\Common\VaultManager::saveVaultedCard</code> and broadcasts the <code>NOTIFY_PAYPALR_VAULT_CARD_SAVED</code> notifier so observers can act on newly stored or updated instruments.</p>
+    <p>Custom code can reuse those vaulted instruments to bill recurring subscriptions or other merchant-initiated payments without prompting customers for their card details again:</p>
+    <ol>
+        <li>Load the module's autoloader before referencing any of its classes:
+            <pre><code>&lt;?php
+require_once DIR_FS_CATALOG . 'includes/modules/payment/paypal/pprAutoload.php';
+            </code></pre>
+        </li>
+        <li>Fetch the customer's vaulted records using <code>paypalr::getVaultedCardsForCustomer($customers_id, $activeOnly = true)</code> or <code>PayPalRestful\Common\VaultManager::getCustomerVaultedCards($customers_id)</code>. Each entry contains the vault identifier, status, masked digits, expiry date, billing address, and a normalized copy of the original <code>payment_source.card</code> array returned by PayPal.</li>
+        <li>Instantiate <code>PayPalRestful\Api\PayPalRestfulApi</code> with the credentials from <code>paypalr::getEnvironmentInfo()</code> and create a new order that references the stored card. A minimal capture-only example looks like:
+            <pre><code>&lt;?php
+[$clientId, $clientSecret] = paypalr::getEnvironmentInfo();
+$api = new \PayPalRestful\Api\PayPalRestfulApi(MODULE_PAYMENT_PAYPALR_SERVER, $clientId, $clientSecret);
+
+$card = $vaultCards[0]; // Obtained in the previous step
+
+$orderRequest = [
+    'intent' =&gt; 'CAPTURE',
+    'purchase_units' =&gt; [[
+        'amount' =&gt; [
+            'currency_code' =&gt; 'USD',
+            'value' =&gt; '10.00',
+        ],
+    ]],
+    'payment_source' =&gt; [
+        'card' =&gt; [
+            'vault_id' =&gt; $card['vault_id'],
+            'expiry' =&gt; $card['expiry'],
+            'last_digits' =&gt; $card['last_digits'],
+            'billing_address' =&gt; $card['billing_address'],
+            'attributes' =&gt; [
+                'stored_credential' =&gt; [
+                    'payment_initiator' =&gt; 'MERCHANT',
+                    'payment_type' =&gt; 'RECURRING',
+                    'usage' =&gt; 'SUBSEQUENT',
+                ],
+            ],
+        ],
+    ],
+];
+
+$createResponse = $api-&gt;createOrder($orderRequest);
+$captureResponse = $api-&gt;captureOrder($createResponse['id']);
+            </code></pre>
+            <p>Adjust the purchase units, intent, and stored credential metadata to match your billing scenario. PayPal's <a href="https://developer.paypal.com/docs/multiparty/seller/checkout/facilitator/vault/" target="_blank">vault documentation</a> covers additional optional fields, such as supplying the previous network transaction reference.</p>
+        </li>
+        <li>Once PayPal returns the new authorization or capture, call <code>VaultManager::saveVaultedCard($customers_id, $orders_id, $payment_source['card'])</code> with the updated response so the vault record's <em>last used</em> timestamp and status stay current.</li>
+    </ol>
+
     <h2>Installation and Upgrade</h2>
     <h3>Initial Installation</h3>
     <h4>Before you start &hellip;</h4>


### PR DESCRIPTION
## Summary
- describe how vaulted card data is stored and exposed for third-party code in the README
- mirror the new instructions in the HTML readme, including a sample flow that reuses a vault token for recurring billing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cc956516608325ba068819660f830f