### PR TITLE
Document ISU flow and add payload tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,27 @@ The module's operation has been validated …
 4. With both the built-in responsive_classic and [ZCA Bootstrap](https://www.zen-cart.com/downloads.php?do=file&id=2191) (v3.6.2-3.7.7) templates.
 
 For additional information, refer to the payment-module's [wiki articles](https://github.com/lat9/paypalr/wiki).
+
+## Integrated sign-up (ISU)
+
+Zen Cart's admin exposes a **Complete PayPal setup** button that launches PayPal's integrated sign-up (ISU) experience. The helper posts the store's metadata to PayPal, opens the hosted onboarding flow in a new window, and then routes the merchant back through `admin/paypalr_integrated_signup.php` so the module can finish configuration.
+
+### Prerequisites
+
+* Install the module and apply the required `order_total` notifier patch.
+* Populate the storefront metadata that ISU sends to PayPal (store name, owner name, and owner email address) from Zen Cart's configuration.
+* Provide PayPal partner credentials for both sandbox and live environments without committing secrets to version control. Use either `includes/local/paypal_partner_credentials.php` (not shipped in the plugin package) or set environment variables:
+  * `PAYPAL_PARTNER_CLIENT_ID_SANDBOX` / `PAYPAL_PARTNER_CLIENT_SECRET_SANDBOX`
+  * `PAYPAL_PARTNER_CLIENT_ID_LIVE` / `PAYPAL_PARTNER_CLIENT_SECRET_LIVE`
+
+### Sandbox versus live
+
+The module chooses the sandbox or live onboarding flow based on the **PayPal Server** setting (`MODULE_PAYMENT_PAYPALR_SERVER`). Sandbox flows let you test onboarding without touching production accounts. Live onboarding requires production partner credentials and writes the resulting merchant credentials back to your configuration (via the helper's `paypalr_isu` session data) once PayPal redirects to Zen Cart.
+
+### Partner attribution and redirects
+
+PayPal requires partners to identify themselves whenever merchants onboard. The helper injects PayPal's partner attribution id `NuminixPPCP_SP` into the API request and sets both return and cancel URLs so PayPal can route the merchant back to `admin/paypalr_integrated_signup.php?action=return` or `action=cancel`. After a successful return the helper verifies the onboarding status, stores the newly issued merchant credentials, and finally redirects the administrator to the Payment Modules page.
+
+## Partner credential packaging guidance
+
+Partner credentials should never be committed to a repository or shipped in a plugin archive. Keep secrets in `includes/local/paypal_partner_credentials.php` (which stays outside the distribution) or rely on environment variables when deploying to staging and production. The helper reads from the local configuration file first and then from the environment, making it safe to package the module without exposing API keys.

--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -100,6 +100,8 @@ class PayPalRestfulApi extends ErrorInfo
     private string $clientId;
     private string $clientSecret;
 
+    public const PARTNER_ATTRIBUTION_ID = 'NuminixPPCP_SP';
+
     /**
      * PayPal partner identifier, used for onboarding follow-up requests.
      */
@@ -765,7 +767,7 @@ class PayPalRestfulApi extends ErrorInfo
             'Content-Type: application/json',
             "Authorization: Bearer $oauth2_token",
             'Prefer: return=representation',
-            'PayPal-Partner-Attribution-Id: NuminixPPCP_SP',
+            'PayPal-Partner-Attribution-Id: ' . self::PARTNER_ATTRIBUTION_ID,
         ];
 
         // -----

--- a/readme_paypalr.html
+++ b/readme_paypalr.html
@@ -118,6 +118,28 @@ table table {
     <p>For additional information, refer to the payment-module's <a href="https://github.com/lat9/paypalr/wiki" target="_blank">wiki articles</a>.</p>
     <p><b>Credits:</b> CSS-based spinner compliments of <a href="https://loading.io/css/" target="_blank">loading.io css spinner</a>.</p>
 
+    <h2>Integrated sign-up (ISU)</h2>
+    <p>Zen Cart's admin exposes a <b>Complete PayPal setup</b> button that launches PayPal's integrated sign-up (ISU) experience. The helper posts your store's metadata to PayPal, opens the hosted onboarding flow in a new window, and then routes the merchant back through <code>admin/paypalr_integrated_signup.php</code> so the module can finish configuration.</p>
+
+    <h3>Prerequisites</h3>
+    <ul>
+        <li>Install the module and apply the required <code>order_total</code> notifier patch.</li>
+        <li>Populate Zen Cart's core configuration values for store name, owner name and owner email address so ISU can share them with PayPal.</li>
+        <li>Provide PayPal partner credentials for sandbox and live without committing secrets to version control. Either create <code>includes/local/paypal_partner_credentials.php</code> (not shipped in the plugin package) or set environment variables:<ul>
+            <li><code>PAYPAL_PARTNER_CLIENT_ID_SANDBOX</code> / <code>PAYPAL_PARTNER_CLIENT_SECRET_SANDBOX</code></li>
+            <li><code>PAYPAL_PARTNER_CLIENT_ID_LIVE</code> / <code>PAYPAL_PARTNER_CLIENT_SECRET_LIVE</code></li>
+        </ul></li>
+    </ul>
+
+    <h3>Sandbox versus live</h3>
+    <p>The module chooses the sandbox or live onboarding flow based on the <b>PayPal Server</b> setting (<code>MODULE_PAYMENT_PAYPALR_SERVER</code>). Sandbox lets you rehearse onboarding, while live requires production partner credentials and, after PayPal redirects to Zen Cart, stores the new merchant credentials via the helper's <code>paypalr_isu</code> session data.</p>
+
+    <h3>Partner attribution and redirects</h3>
+    <p>The helper injects PayPal's partner attribution id <code>NuminixPPCP_SP</code> into the API request and sets return and cancel URLs so PayPal can route the merchant back to <code>admin/paypalr_integrated_signup.php?action=return</code> or <code>action=cancel</code>. After a successful return the helper verifies the onboarding status, stores the issued merchant credentials, and then redirects the administrator to the Payment Modules page.</p>
+
+    <h2>Partner credential packaging guidance</h2>
+    <p>Partner credentials should never be stored in your repository or included in a distribution archive. Keep secrets in <code>includes/local/paypal_partner_credentials.php</code> (which remains outside of the packaged plugin) or supply them through environment variables for staging and production deployments. The helper checks the local configuration first and then the environment, allowing you to ship the module without exposing API keys.</p>
+
     <h2>Installation and Upgrade</h2>
     <h3>Initial Installation</h3>
     <h4>Before you start &hellip;</h4>

--- a/tests/IntegratedSignupPayloadTest.php
+++ b/tests/IntegratedSignupPayloadTest.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+namespace PayPalRestful\Common {
+    class Logger
+    {
+        public function __construct(string $name = '')
+        {
+        }
+
+        public function enableDebug(): void
+        {
+        }
+
+        public function write(string $message, bool $includeTimestamp = false, string $includeSeparator = ''): void
+        {
+        }
+
+        public static function logJSON($data, bool $keep_links = false, bool $use_var_export = false): string
+        {
+            return json_encode($data);
+        }
+    }
+}
+
+namespace PayPalRestful\Api {
+    class PayPalRestfulApi
+    {
+        public const PARTNER_ATTRIBUTION_ID = 'NuminixPPCP_SP';
+
+        public static array $lastConstruct = [];
+        public static array $lastPayload = [];
+        public static $nextResponse = null;
+        public static array $nextError = [];
+
+        public function __construct(string $environment, string $clientId, string $clientSecret)
+        {
+            self::$lastConstruct = [
+                'environment' => $environment,
+                'client_id' => $clientId,
+                'client_secret' => $clientSecret,
+            ];
+        }
+
+        public function createPartnerReferral(array $payload)
+        {
+            self::$lastPayload = $payload;
+            return self::$nextResponse;
+        }
+
+        public function getErrorInfo(): array
+        {
+            return self::$nextError;
+        }
+    }
+}
+
+namespace {
+    class paypalr
+    {
+        public static array $credentials = [
+            'sandbox' => ['sandbox-partner-id', 'sandbox-partner-secret'],
+            'live' => ['live-partner-id', 'live-partner-secret'],
+        ];
+
+        public static function getPartnerCredentials(string $environment): array
+        {
+            $environment = (strtolower($environment) === 'live') ? 'live' : 'sandbox';
+            return self::$credentials[$environment] ?? ['', ''];
+        }
+    }
+
+    if (!defined('DIR_FS_CATALOG')) {
+        define('DIR_FS_CATALOG', __DIR__ . '/../');
+    }
+    if (!defined('DIR_WS_CATALOG')) {
+        define('DIR_WS_CATALOG', 'store/');
+    }
+    if (!defined('STORE_NAME')) {
+        define('STORE_NAME', 'Unit Test Store');
+    }
+    if (!defined('STORE_OWNER')) {
+        define('STORE_OWNER', 'Pat Merchant');
+    }
+    if (!defined('STORE_OWNER_EMAIL_ADDRESS')) {
+        define('STORE_OWNER_EMAIL_ADDRESS', 'owner@example.com');
+    }
+    if (!defined('HTTPS_SERVER')) {
+        define('HTTPS_SERVER', 'https://example.com');
+    }
+    if (!defined('HTTP_SERVER')) {
+        define('HTTP_SERVER', 'http://example.com');
+    }
+    if (!defined('FILENAME_MODULES')) {
+        define('FILENAME_MODULES', 'modules.php');
+    }
+    if (!defined('MODULE_PAYMENT_PAYPALR_DEBUGGING')) {
+        define('MODULE_PAYMENT_PAYPALR_DEBUGGING', 'Off');
+    }
+
+    if (!function_exists('zen_href_link')) {
+        function zen_href_link(string $page = '', string $parameters = '', string $connection = 'NONSSL'): string
+        {
+            $scheme = ($connection === 'SSL') ? 'https://example.com/admin/' : 'http://example.com/admin/';
+            $url = $scheme . ltrim($page, '/');
+            if ($parameters !== '') {
+                $url .= '?' . $parameters;
+            }
+            return $url;
+        }
+    }
+
+    require_once __DIR__ . '/../includes/modules/payment/paypal/PayPalRestful/Admin/IntegratedSignup.php';
+}
+
+namespace PayPalRestful\Tests {
+    use PayPalRestful\Admin\IntegratedSignup;
+    use PayPalRestful\Api\PayPalRestfulApi;
+    use PHPUnit\Framework\TestCase;
+
+    final class IntegratedSignupPayloadTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            PayPalRestfulApi::$nextResponse = null;
+            PayPalRestfulApi::$nextError = [];
+            PayPalRestfulApi::$lastPayload = [];
+            PayPalRestfulApi::$lastConstruct = [];
+        }
+
+        public function testPayloadIncludesStoreMetadataAndRedirects(): void
+        {
+            PayPalRestfulApi::$nextResponse = [
+                'links' => [
+                    ['rel' => 'self', 'href' => 'https://example.com/api/referrals/1'],
+                    ['rel' => 'action_url', 'href' => 'https://onboarding.example.com/start'],
+                ],
+                'partner_referral_id' => 'TEST-REFERRAL-ID',
+            ];
+
+            $signup = new IntegratedSignup('LIVE');
+
+            $this->assertTrue($signup->createReferral());
+            $payload = $signup->getLastPayload();
+
+            $this->assertSame('live', $signup->getEnvironment());
+            $this->assertSame('https://onboarding.example.com/start', $signup->getActionUrl());
+            $this->assertSame('TEST-REFERRAL-ID', $signup->getReferralId());
+
+            $this->assertArrayHasKey('tracking_id', $payload);
+            $this->assertNotSame('', $payload['tracking_id']);
+            $this->assertStringStartsWith('zen-', $payload['tracking_id']);
+
+            $this->assertSame('Unit Test Store', $payload['business_information']['business_name']);
+            $this->assertSame(['https://example.com/store'], $payload['business_information']['website_urls']);
+            $this->assertSame('owner@example.com', $payload['business_information']['customer_service_email']);
+
+            $contact = $payload['contact_information'];
+            $this->assertSame('owner@example.com', $contact['email_address']);
+            $this->assertSame('Pat', $contact['name']['given_name']);
+            $this->assertSame('Merchant', $contact['name']['surname']);
+
+            $override = $payload['partner_config_override'];
+            $this->assertSame('Unit Test Store', $override['display_name']);
+            $this->assertSame('https://example.com/admin/paypalr_integrated_signup.php?action=return', $override['return_url']);
+
+            $restIntegration = $payload['operations'][0]['api_integration_preference']['rest_api_integration'];
+            $this->assertSame(PayPalRestfulApi::PARTNER_ATTRIBUTION_ID, $restIntegration['third_party_details']['partner_attribution_id']);
+            $this->assertContains('PAYMENT', $restIntegration['third_party_details']['features']);
+
+            $redirects = $restIntegration['redirect_urls'];
+            $this->assertSame('https://example.com/admin/paypalr_integrated_signup.php?action=return', $redirects['return_url']);
+            $this->assertSame('https://example.com/admin/paypalr_integrated_signup.php?action=cancel', $redirects['cancel_url']);
+
+            $this->assertNotEmpty($signup->getLinks());
+        }
+
+        public function testCreateReferralCapturesApiError(): void
+        {
+            PayPalRestfulApi::$nextResponse = false;
+            PayPalRestfulApi::$nextError = [
+                'errMsg' => 'Simulated failure.',
+                'debug_id' => 'DEBUG123',
+                'details' => [],
+            ];
+
+            $signup = new IntegratedSignup('sandbox');
+
+            $this->assertFalse($signup->createReferral());
+            $this->assertSame(PayPalRestfulApi::$nextError, $signup->getError());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document the integrated sign-up (ISU) button, partner attribution, environment flows, and secret handling in README.md and the packaged HTML readme
- expose a reusable partner attribution constant and extend the ISU payload builder to include redirect URLs and the attribution id
- add PHPUnit coverage for the ISU helper that verifies payload contents and error handling

## Testing
- php /tmp/phpunit.phar --colors=always tests/IntegratedSignupPayloadTest.php
- php tests/DeterminePayerActionRedirectPageTest.php

------
https://chatgpt.com/codex/tasks/task_b_68cc94d5c6c0832588bfbc992f6c3dd4