### PR TITLE
Fix PayPal autoloader includes to use absolute paths

### DIFF
--- a/admin/paypalr_integrated_signup.php
+++ b/admin/paypalr_integrated_signup.php
@@ -24,7 +24,7 @@ if (!$paypalrAdminLoggedIn) {
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }
 
-require DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
+require DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 use PayPalRestful\Admin\IntegratedSignup;
 use PayPalRestful\Api\PayPalRestfulApi;

--- a/ppr_listener.php
+++ b/ppr_listener.php
@@ -21,7 +21,7 @@ if (!defined('MODULE_PAYMENT_PAYPALR_STATUS') || MODULE_PAYMENT_PAYPALR_STATUS =
     die();
 }
 
-require DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
+require DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Common\Logger;


### PR DESCRIPTION
## Summary
- update `paypalr_integrated_signup.php` to load the PayPal autoloader using the catalog filesystem path so renamed admin directories resolve correctly
- do the same for the `ppr_listener.php` controller to keep autoloader access consistent

## Testing
- php -l admin/paypalr_integrated_signup.php
- php -l ppr_listener.php

------
https://chatgpt.com/codex/tasks/task_b_68cca74f38288325b6363760daf41249