### PR TITLE
Add compatibility zcDate implementation

### DIFF
--- a/includes/auto_loaders/webhook.core.php
+++ b/includes/auto_loaders/webhook.core.php
@@ -15,6 +15,10 @@ if (!class_exists('notifier')) {
     require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/LegacyNotifier.php';
 }
 
+if (!class_exists('zcDate')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/ZcDate.php';
+}
+
 $autoLoadConfig[0][] = [
     'autoType' => 'include',
     'loadFile' => DIR_WS_INCLUDES . 'version.php',

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/ZcDate.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/ZcDate.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Lightweight compatibility implementation of Zen Cart's zcDate class.
+ */
+
+if (class_exists('zcDate')) {
+    return;
+}
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use Exception;
+
+class zcDate
+{
+    private DateTimeZone $timezone;
+
+    public function __construct(?DateTimeZone $timezone = null)
+    {
+        $this->timezone = $timezone ?? new DateTimeZone(date_default_timezone_get());
+    }
+
+    public function setTimeZone(DateTimeZone $timezone): void
+    {
+        $this->timezone = $timezone;
+    }
+
+    public function output(string $format, mixed $timestamp = null): string
+    {
+        $dateTime = $this->normalizeToDateTime($timestamp);
+
+        $convertedFormat = $this->convertFormat($format);
+
+        return $dateTime->setTimezone($this->timezone)->format($convertedFormat);
+    }
+
+    private function normalizeToDateTime(mixed $timestamp): DateTimeImmutable
+    {
+        if ($timestamp instanceof DateTimeInterface) {
+            return DateTimeImmutable::createFromInterface($timestamp);
+        }
+
+        if ($timestamp === null) {
+            return new DateTimeImmutable('now', $this->timezone);
+        }
+
+        if (is_int($timestamp)) {
+            return (new DateTimeImmutable('@' . $timestamp))->setTimezone($this->timezone);
+        }
+
+        if (is_numeric($timestamp)) {
+            return (new DateTimeImmutable('@' . (int) $timestamp))->setTimezone($this->timezone);
+        }
+
+        try {
+            return new DateTimeImmutable((string) $timestamp, $this->timezone);
+        } catch (Exception $exception) {
+            return new DateTimeImmutable('now', $this->timezone);
+        }
+    }
+
+    private function convertFormat(string $format): string
+    {
+        $replacements = [
+            '%a' => 'D',
+            '%A' => 'l',
+            '%b' => 'M',
+            '%B' => 'F',
+            '%d' => 'd',
+            '%e' => 'j',
+            '%H' => 'H',
+            '%I' => 'h',
+            '%m' => 'm',
+            '%M' => 'i',
+            '%p' => 'A',
+            '%S' => 's',
+            '%y' => 'y',
+            '%Y' => 'Y',
+            '%Z' => 'T',
+            '%z' => 'O',
+            '%%' => '%',
+        ];
+
+        $converted = strtr($format, $replacements);
+
+        return preg_replace('/%./', '', $converted) ?? $converted;
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight compatibility implementation of the legacy zcDate helper
- ensure the webhook autoloader loads the compatibility class when the core implementation is unavailable

## Testing
- php tests/DeterminePayerActionRedirectPageTest.php

------
https://chatgpt.com/codex/tasks/task_b_68cdcd334ba88325b12c443a936814c5