### PR TITLE
Add sniffer compatibility shim for webhook handler

### DIFF
--- a/includes/auto_loaders/webhook.core.php
+++ b/includes/auto_loaders/webhook.core.php
@@ -19,6 +19,10 @@ if (!class_exists('zcDate')) {
     require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/ZcDate.php';
 }
 
+if (!class_exists('sniffer')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/Sniffer.php';
+}
+
 $autoLoadConfig[0][] = [
     'autoType' => 'include',
     'loadFile' => DIR_WS_INCLUDES . 'version.php',
@@ -76,7 +80,6 @@ $autoLoadConfig[45][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_non_db_settings.php',
 ];
-//- sniffer class loaded via psr4Autoload.php
 $autoLoadConfig[50][] = [
     'autoType' => 'classInstantiate',
     'className' => 'sniffer',

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/Sniffer.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/Sniffer.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Lightweight compatibility implementation of Zen Cart's sniffer class.
+ */
+
+if (class_exists('sniffer')) {
+    return;
+}
+
+class sniffer
+{
+    /**
+     * Database adapter instance.
+     */
+    private mixed $db = null;
+
+    public function __construct(mixed $db = null)
+    {
+        if ($db !== null) {
+            $this->db = $db;
+            return;
+        }
+
+        if (isset($GLOBALS['db']) && is_object($GLOBALS['db'])) {
+            $this->db = $GLOBALS['db'];
+        }
+    }
+
+    public function field_exists(string $tableName, string $columnName): bool
+    {
+        return $this->describeColumn($tableName, $columnName) !== null;
+    }
+
+    public function field_type(string $tableName, string $columnName, string $expectedType): bool
+    {
+        $column = $this->describeColumn($tableName, $columnName);
+        if ($column === null) {
+            return false;
+        }
+
+        $actualType = $this->extractColumnType($column);
+        if ($actualType === null) {
+            return false;
+        }
+
+        return $this->normalizeType($actualType) === $this->normalizeType($expectedType);
+    }
+
+    private function describeColumn(string $tableName, string $columnName): ?array
+    {
+        $db = $this->resolveDb();
+        if ($db === null) {
+            return null;
+        }
+
+        $quotedTable = $this->quoteIdentifier($tableName);
+        $escapedColumn = $this->escapeValue($columnName);
+
+        if ($quotedTable === '' || $escapedColumn === '') {
+            return null;
+        }
+
+        $sql = sprintf("SHOW COLUMNS FROM %s LIKE '%s'", $quotedTable, $escapedColumn);
+
+        try {
+            $result = $db->Execute($sql);
+        } catch (\Throwable $exception) {
+            return null;
+        }
+
+        return $this->extractFirstRow($result);
+    }
+
+    private function resolveDb(): mixed
+    {
+        if (isset($this->db) && is_object($this->db)) {
+            return $this->db;
+        }
+
+        if (isset($GLOBALS['db']) && is_object($GLOBALS['db'])) {
+            $this->db = $GLOBALS['db'];
+            return $this->db;
+        }
+
+        return null;
+    }
+
+    private function extractFirstRow(mixed $result): ?array
+    {
+        if (is_array($result)) {
+            if (empty($result)) {
+                return null;
+            }
+
+            $first = reset($result);
+            return is_array($first) ? $first : (array) $first;
+        }
+
+        if (!is_object($result)) {
+            return null;
+        }
+
+        if (isset($result->EOF) && $result->EOF) {
+            return null;
+        }
+
+        if (isset($result->fields) && is_array($result->fields) && !empty($result->fields)) {
+            return $result->fields;
+        }
+
+        if (method_exists($result, 'fields')) {
+            $fields = $result->fields();
+            if (is_array($fields) && !empty($fields)) {
+                return $fields;
+            }
+        }
+
+        if (method_exists($result, 'fetch_assoc')) {
+            $row = $result->fetch_assoc();
+            if (is_array($row) && !empty($row)) {
+                return $row;
+            }
+        }
+
+        if (method_exists($result, 'fetch')) {
+            $row = $result->fetch();
+            if ($row) {
+                return (array) $row;
+            }
+        }
+
+        if ($result instanceof \Traversable) {
+            foreach ($result as $row) {
+                return is_array($row) ? $row : (array) $row;
+            }
+            return null;
+        }
+
+        if (isset($result->fields) && is_array($result->fields)) {
+            return $result->fields;
+        }
+
+        return null;
+    }
+
+    private function extractColumnType(array $column): ?string
+    {
+        foreach (['Type', 'type', 1] as $key) {
+            if (isset($column[$key])) {
+                return (string) $column[$key];
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeType(string $type): string
+    {
+        $lower = strtolower($type);
+        $stripped = preg_replace('/\s+/', '', $lower);
+
+        return $stripped ?? $lower;
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        $trimmed = trim($identifier);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $parts = explode('.', $trimmed);
+        foreach ($parts as &$part) {
+            $part = '`' . str_replace('`', '``', $part) . '`';
+        }
+
+        return implode('.', $parts);
+    }
+
+    private function escapeValue(string $value): string
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        return addcslashes($trimmed, "\\_%'");
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight `sniffer` compatibility class so the webhook autoloader can instantiate it when the core class is unavailable
- ensure the webhook autoloader loads the compatibility shim before instantiating the class

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Compatibility/Sniffer.php
- php -l includes/auto_loaders/webhook.core.php

------
https://chatgpt.com/codex/tasks/task_b_68cedef3639c83259fe317797d16020e