### PR TITLE
Add shopping cart compatibility shim for webhook bootstrap

### DIFF
--- a/includes/auto_loaders/webhook.core.php
+++ b/includes/auto_loaders/webhook.core.php
@@ -23,6 +23,10 @@ if (!class_exists('sniffer')) {
     require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/Sniffer.php';
 }
 
+if (!class_exists('shoppingCart')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/ShoppingCart.php';
+}
+
 $autoLoadConfig[0][] = [
     'autoType' => 'include',
     'loadFile' => DIR_WS_INCLUDES . 'version.php',

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/ShoppingCart.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/ShoppingCart.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Lightweight compatibility implementation of Zen Cart's shoppingCart class.
+ *
+ * This shim provides the minimal surface area required by the REST webhook
+ * bootstrap so that webhook requests can be processed in environments where the
+ * full Zen Cart storefront stack isn't available (e.g. stand-alone webhook
+ * endpoints).
+ */
+
+if (class_exists('shoppingCart')) {
+    return;
+}
+
+class shoppingCart
+{
+    /**
+     * In-memory representation of cart contents keyed by product identifier.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $contents = [];
+
+    /**
+     * Cached total value of items in the cart.
+     */
+    protected float $total = 0.0;
+
+    /**
+     * Cached total weight of the cart's contents.
+     */
+    protected float $weight = 0.0;
+
+    /**
+     * Denotes the nature of cart contents (mirrors core behaviour).
+     */
+    protected string $content_type = 'virtual';
+
+    public function __construct()
+    {
+        $this->reset(false);
+    }
+
+    /**
+     * Reset the cart to an empty state.
+     */
+    public function reset($reset_database = false): void
+    {
+        $this->contents = [];
+        $this->total = 0.0;
+        $this->weight = 0.0;
+        $this->content_type = 'virtual';
+    }
+
+    /**
+     * Compatibility placeholder that mirrors the storefront signature.
+     */
+    public function restore_contents(): void
+    {
+        // No-op in compatibility shim.
+    }
+
+    /**
+     * Return the products currently stored in the cart.
+     */
+    public function get_products(): array
+    {
+        return $this->contents;
+    }
+
+    /**
+     * Report how many line-items the cart contains.
+     */
+    public function count_contents(): int
+    {
+        return count($this->contents);
+    }
+
+    /**
+     * Retrieve the cached cart total.
+     */
+    public function show_total(): float
+    {
+        return $this->total;
+    }
+
+    /**
+     * Retrieve the cached cart weight.
+     */
+    public function show_weight(): float
+    {
+        return $this->weight;
+    }
+
+    /**
+     * Determine whether a product is present in the cart.
+     */
+    public function in_cart(string $product_id): bool
+    {
+        return isset($this->contents[$product_id]);
+    }
+
+    /**
+     * Add or update a product within the cart.
+     */
+    public function add_cart($product_id, $quantity = 1, $attributes = [], $notify = true): void
+    {
+        $this->contents[$product_id] = [
+            'id' => $product_id,
+            'quantity' => (int) $quantity,
+            'attributes' => $attributes,
+        ];
+
+        $this->recalculateTotals();
+    }
+
+    /**
+     * Return the configured content type for the cart.
+     */
+    public function get_content_type(): string
+    {
+        return $this->content_type;
+    }
+
+    /**
+     * Allow external code to override the cart's content classification.
+     */
+    public function set_content_type(string $content_type): void
+    {
+        $this->content_type = $content_type;
+    }
+
+    /**
+     * Recalculate the derived totals for the cart.
+     */
+    protected function recalculateTotals(): void
+    {
+        $this->total = 0.0;
+        $this->weight = 0.0;
+
+        foreach ($this->contents as $item) {
+            $quantity = (int) ($item['quantity'] ?? 0);
+            $this->total += 0.0 * $quantity;
+            $this->weight += 0.0 * $quantity;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight shoppingCart compatibility implementation so the webhook bootstrap can instantiate the cart in minimal environments
- ensure the webhook autoloader pulls in the compatibility class when the core shoppingCart class is unavailable

## Testing
- php -l includes/modules/payment/paypal/PayPalRestful/Compatibility/ShoppingCart.php

------
https://chatgpt.com/codex/tasks/task_b_68dbfcbc6b188325941f57abf1b2ba6e