### PR TITLE
Add compatibility shims for webhook bootstrap

### DIFF
--- a/includes/auto_loaders/webhook.core.php
+++ b/includes/auto_loaders/webhook.core.php
@@ -26,6 +26,18 @@ if (!class_exists('sniffer')) {
 if (!class_exists('shoppingCart')) {
     require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/ShoppingCart.php';
 }
+if (!class_exists('cache')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/Cache.php';
+}
+if (!class_exists('currencies')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/Currencies.php';
+}
+if (!class_exists('template_func')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/TemplateFunc.php';
+}
+if (!class_exists('messageStack')) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Compatibility/MessageStack.php';
+}
 
 $autoLoadConfig[0][] = [
     'autoType' => 'include',

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/Cache.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/Cache.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Minimal cache compatibility class.
+ */
+
+if (class_exists('cache')) {
+    return;
+}
+
+class cache
+{
+    /** @var array<string, mixed> */
+    protected array $storage = [];
+
+    public function __construct()
+    {
+    }
+
+    public function clear_cache(string $name = ''): void
+    {
+        if ($name === '') {
+            $this->storage = [];
+            return;
+        }
+
+        unset($this->storage[$name]);
+    }
+
+    public function write(string $name, $value, int $ttl = 0): void
+    {
+        $this->storage[$name] = $value;
+    }
+
+    public function read(string $name)
+    {
+        return $this->storage[$name] ?? false;
+    }
+
+    public function sql_cache_flush_cache(): void
+    {
+        $this->storage = [];
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        // Silently ignore undefined cache interactions for compatibility.
+        return null;
+    }
+}

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/Currencies.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/Currencies.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Lightweight compatibility shim for Zen Cart's currencies class.
+ *
+ * Provides the minimal surface area required by the PayPal REST webhook
+ * bootstrap so that execution can continue in environments where the full
+ * storefront stack is unavailable.
+ */
+
+if (class_exists('currencies')) {
+    return;
+}
+
+class currencies
+{
+    /**
+     * Registry of currency codes mapped to their conversion rates.
+     *
+     * @var array<string, array{value: float}>
+     */
+    protected array $currencies = [];
+
+    public function __construct(array $currencies = [])
+    {
+        foreach ($currencies as $code => $currency) {
+            $rate = is_array($currency) ? ($currency['value'] ?? 1.0) : (float) $currency;
+            $this->set($code, (float) $rate);
+        }
+
+        $this->ensureCurrencyDefined(defined('DEFAULT_CURRENCY') ? (string) DEFAULT_CURRENCY : null);
+        $this->ensureCurrencyDefined(defined('MODULE_PAYMENT_PAYPALR_CURRENCY_FALLBACK') ? (string) MODULE_PAYMENT_PAYPALR_CURRENCY_FALLBACK : null);
+    }
+
+    /**
+     * Store a conversion rate for the supplied currency code.
+     */
+    public function set(string $code, float $value): void
+    {
+        $code = strtoupper($code);
+        if ($code === '') {
+            return;
+        }
+
+        $this->currencies[$code] = ['value' => $value === 0.0 ? 1.0 : $value];
+    }
+
+    /**
+     * Determine whether a currency has been configured.
+     */
+    public function is_set(string $code): bool
+    {
+        $code = strtoupper($code);
+        if ($code === '') {
+            return false;
+        }
+
+        $this->ensureCurrencyDefined($code);
+
+        return isset($this->currencies[$code]);
+    }
+
+    /**
+     * Convert a value into the requested currency.
+     */
+    public function rateAdjusted($value, bool $use_defaults = true, string $currency_code = ''): float
+    {
+        $value = (float) $value;
+        $currency_code = strtoupper($currency_code);
+
+        if ($currency_code === '' && defined('DEFAULT_CURRENCY')) {
+            $currency_code = (string) strtoupper((string) DEFAULT_CURRENCY);
+        }
+
+        if ($currency_code !== '' && $this->is_set($currency_code)) {
+            $rate = (float) ($this->currencies[$currency_code]['value'] ?? 1.0);
+            return $value * ($rate === 0.0 ? 1.0 : $rate);
+        }
+
+        if ($use_defaults && defined('MODULE_PAYMENT_PAYPALR_CURRENCY_FALLBACK')) {
+            $fallback = strtoupper((string) MODULE_PAYMENT_PAYPALR_CURRENCY_FALLBACK);
+            if ($this->is_set($fallback)) {
+                $rate = (float) ($this->currencies[$fallback]['value'] ?? 1.0);
+                return $value * ($rate === 0.0 ? 1.0 : $rate);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Ensure that the specified currency exists in the registry.
+     */
+    protected function ensureCurrencyDefined(?string $code): void
+    {
+        if ($code === null) {
+            return;
+        }
+
+        $code = strtoupper($code);
+        if ($code === '') {
+            return;
+        }
+
+        $this->currencies += [$code => ['value' => $this->currencies[$code]['value'] ?? 1.0]];
+    }
+}

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/MessageStack.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/MessageStack.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Lightweight messageStack compatibility class.
+ */
+
+if (class_exists('messageStack')) {
+    return;
+}
+
+class messageStack
+{
+    /** @var array<string, array<int, array{text: string, type: string}>> */
+    protected array $messages = [];
+
+    public function add_session($stack, $message = null, $type = 'error'): void
+    {
+        if ($message === null) {
+            $message = (string) $stack;
+            $stack = 'header';
+        }
+
+        $stack = $this->normaliseStackName($stack);
+        $this->messages[$stack][] = ['text' => (string) $message, 'type' => (string) $type];
+
+        if (!isset($_SESSION) || !is_array($_SESSION)) {
+            $_SESSION = [];
+        }
+        if (!isset($_SESSION['messageToStack']) || !is_array($_SESSION['messageToStack'])) {
+            $_SESSION['messageToStack'] = [];
+        }
+        $_SESSION['messageToStack'][$stack][] = ['text' => (string) $message, 'type' => (string) $type];
+    }
+
+    public function add($stack, $message, $type = 'error'): void
+    {
+        $stack = $this->normaliseStackName($stack);
+        $this->messages[$stack][] = ['text' => (string) $message, 'type' => (string) $type];
+    }
+
+    public function size($stack = 'header'): int
+    {
+        $stack = $this->normaliseStackName($stack);
+
+        return count($this->messages[$stack] ?? []);
+    }
+
+    public function reset(): void
+    {
+        $this->messages = [];
+    }
+
+    protected function normaliseStackName($stack): string
+    {
+        $stack = (string) $stack;
+        $stack = trim($stack);
+
+        if ($stack === '') {
+            return 'header';
+        }
+
+        return $stack;
+    }
+}

--- a/includes/modules/payment/paypal/PayPalRestful/Compatibility/TemplateFunc.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Compatibility/TemplateFunc.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Minimal compatibility layer for Zen Cart's template_func helper.
+ */
+
+if (class_exists('template_func')) {
+    return;
+}
+
+class template_func
+{
+    /**
+     * Determine the directory that should contain the requested template asset.
+     */
+    public function get_template_dir($file, string $base_dir, $current_page_base = '', string $template_type = 'templates'): string
+    {
+        $base_dir = $this->normaliseBaseDir($base_dir);
+        $template_candidates = $this->candidateDirectories($base_dir, $template_type);
+
+        foreach ($template_candidates as $directory) {
+            if ($this->templateFileExists($directory, $file)) {
+                return $directory;
+            }
+        }
+
+        return $template_candidates[0] ?? $base_dir;
+    }
+
+    protected function normaliseBaseDir(string $base_dir): string
+    {
+        if ($base_dir === '') {
+            $base_dir = 'includes/templates/';
+        }
+
+        if ($base_dir[0] === '/' || preg_match('/^[A-Za-z]:\\\\/', $base_dir) === 1) {
+            return rtrim($base_dir, '/');
+        }
+
+        $catalog = defined('DIR_FS_CATALOG') ? rtrim((string) DIR_FS_CATALOG, '/') : getcwd();
+
+        return rtrim($catalog . '/' . ltrim($base_dir, '/'), '/');
+    }
+
+    protected function candidateDirectories(string $base_dir, string $template_type): array
+    {
+        $directories = [];
+        $template_directory = $this->determineTemplateDirectory();
+
+        if ($template_directory !== null) {
+            $directories[] = $base_dir . '/' . $template_directory . '/' . $template_type;
+        }
+
+        $directories[] = $base_dir . '/template_default/' . $template_type;
+
+        return array_values(array_unique(array_map(static fn ($dir) => rtrim($dir, '/'), $directories)));
+    }
+
+    protected function determineTemplateDirectory(): ?string
+    {
+        if (defined('DIR_WS_TEMPLATE')) {
+            $template = basename(rtrim((string) DIR_WS_TEMPLATE, '/'));
+            if ($template !== '' && $template !== '.' && $template !== '..') {
+                return $template;
+            }
+        }
+
+        if (!empty($_SESSION['tplDir'])) {
+            $template = basename((string) $_SESSION['tplDir']);
+            if ($template !== '' && $template !== '.' && $template !== '..') {
+                return $template;
+            }
+        }
+
+        return null;
+    }
+
+    protected function templateFileExists(string $directory, $file): bool
+    {
+        if (!is_dir($directory)) {
+            return false;
+        }
+
+        $directory = rtrim($directory, '/');
+        $pattern = $this->normalisePattern($file);
+
+        if ($pattern === null) {
+            $path = $directory . '/' . ltrim((string) $file, '/');
+            return is_file($path);
+        }
+
+        foreach (glob($directory . '/*') ?: [] as $candidate) {
+            if (preg_match($pattern, basename($candidate))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function normalisePattern($pattern): ?string
+    {
+        if (!is_string($pattern)) {
+            return null;
+        }
+
+        if ($pattern === '') {
+            return null;
+        }
+
+        if ($pattern[0] !== '^' && strpos($pattern, '*') === false) {
+            return null;
+        }
+
+        $delimited = '#'
+            . str_replace('#', '\\#', strtr($pattern, ['*' => '.*']))
+            . '#i';
+
+        return $delimited;
+    }
+}


### PR DESCRIPTION
## Summary
- add lightweight compatibility implementations for cache, currencies, messageStack, and template_func so webhook bootstrap can run without the storefront stack
- load the new shims from the webhook autoloader alongside the existing compatibility classes

## Testing
- php tests/CreatePayPalOrderRequestShippingDiscountTest.php
- php tests/DeterminePayerActionRedirectPageTest.php

------
https://chatgpt.com/codex/tasks/task_b_68dc3bbf07608325afc8d1a8d98f3df1