### PR TITLE
Fix invalid 3DS URLs for PayPal card payments

### DIFF
--- a/includes/modules/payment/paypalr.php
+++ b/includes/modules/payment/paypalr.php
@@ -1237,7 +1237,8 @@ class paypalr extends base
             'expiry_month' => $cc_validation->cc_expiry_month,
             'expiry_year' => $cc_validation->cc_expiry_year,
             'name' => $cc_owner,
-            'security_code' => $cvv_posted
+            'security_code' => $cvv_posted,
+            'redirect' => $this->getListenerEndpoint(),
         ];
         return true;
     }


### PR DESCRIPTION
## Summary
- store the listener endpoint with captured card details so SCA return URLs have a base path
- normalize the generated experience_context URLs to ensure absolute return/cancel targets for 3DS flows

## Testing
- php -l includes/modules/payment/paypalr.php
- php -l includes/modules/payment/paypal/PayPalRestful/Zc2Pp/CreatePayPalOrderRequest.php

------
https://chatgpt.com/codex/tasks/task_b_68dffbc93ccc8325b2d813f58af150cc