### PR TITLE
Load PayPal JS SDK selectively and add configurable SDK pages; bump to v1.3.15

### DIFF
--- a/includes/classes/observers/auto.paypaladvcheckout.php
+++ b/includes/classes/observers/auto.paypaladvcheckout.php
@@ -111,11 +111,13 @@ class zcObserverPaypaladvcheckout
         }
 
         // -----
-        // Attach to header to render JS SDK assets.
-        $this->attach($this, ['NOTIFY_HTML_HEAD_JS_BEGIN']); // NOTE: this might come too early to detect pageType properly
-        $this->attach($this, ['NOTIFY_HTML_HEAD_END']);
-        // Attach to footer to instantiate the JS.
-        $this->attach($this, ['NOTIFY_FOOTER_END']);
+        // Attach to header/footer to render JS SDK assets only on pages that
+        // are known to need PayPal SDK support.
+        if ($this->shouldLoadJsSdkForPage((string)$current_page_base)) {
+            $this->attach($this, ['NOTIFY_HTML_HEAD_JS_BEGIN']); // NOTE: this might come too early to detect pageType properly
+            $this->attach($this, ['NOTIFY_HTML_HEAD_END']);
+            $this->attach($this, ['NOTIFY_FOOTER_END']);
+        }
     }
 
     // -----
@@ -224,6 +226,76 @@ class zcObserverPaypaladvcheckout
         }
 
         return array_values(array_unique($pageKeys));
+    }
+
+    protected function shouldLoadJsSdkForPage(string $current_page): bool
+    {
+        if ($current_page === '' || $current_page === 'page_not_found') {
+            return false;
+        }
+        if (defined('FILENAME_PAGE_NOT_FOUND') && $current_page === FILENAME_PAGE_NOT_FOUND) {
+            return false;
+        }
+
+        if (strpos($current_page, 'checkout') === 0) {
+            return true;
+        }
+
+        $corePages = [
+            $this->getPageNameFromConstant('FILENAME_DEFAULT', 'index'),
+            $this->getPageNameFromConstant('FILENAME_PRODUCTS_ALL', 'products_all'),
+            $this->getPageNameFromConstant('FILENAME_FEATURED_PRODUCTS', 'featured_products'),
+            $this->getPageNameFromConstant('FILENAME_PRODUCTS_NEW', 'new_products'),
+            $this->getPageNameFromConstant('FILENAME_NEW_PRODUCTS', 'new_products'),
+            $this->getPageNameFromConstant('FILENAME_SPECIALS', 'specials'),
+            $this->getPageNameFromConstant('FILENAME_SHOPPING_CART', 'shopping_cart'),
+            $this->getPageNameFromConstant('FILENAME_AJAX_SHOPPING_CART', 'ajax_shopping_cart'),
+            $this->getPageNameFromConstant('FILENAME_ADVANCED_SEARCH_RESULT', 'advanced_search_result'),
+            $this->getPageNameFromConstant('FILENAME_ACCOUNT_SAVED_CREDIT_CARDS', 'account_saved_credit_cards'),
+        ];
+        $corePages = array_merge($corePages, $this->getNuminixOpcPageKeys(), zen_get_buyable_product_type_handlers());
+        $corePages = array_filter($corePages, static function ($pageName) {
+            return is_string($pageName) && $pageName !== '';
+        });
+
+        if (in_array($current_page, $corePages, true)) {
+            return true;
+        }
+
+        foreach ($this->getConfiguredSdkPages() as $configuredPage) {
+            if ($configuredPage === $current_page) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function getConfiguredSdkPages(): array
+    {
+        if (!defined('MODULE_PAYMENT_PAYPALAC_SDK_PAGES')) {
+            return [];
+        }
+
+        $configuredPages = explode(',', MODULE_PAYMENT_PAYPALAC_SDK_PAGES);
+        $configuredPages = array_map('trim', $configuredPages);
+        $configuredPages = array_filter($configuredPages, static function ($pageName) {
+            return $pageName !== '';
+        });
+
+        return array_values(array_unique($configuredPages));
+    }
+
+    protected function getPageNameFromConstant(string $constantName, string $fallback): string
+    {
+        if (defined($constantName)) {
+            $constantValue = constant($constantName);
+            if (is_string($constantValue) && $constantValue !== '') {
+                return $constantValue;
+            }
+        }
+
+        return $fallback;
     }
 
     // -----
@@ -559,7 +631,11 @@ class zcObserverPaypaladvcheckout
         // Log SDK configuration for debugging purposes. This helps diagnose issues
         // like 400 errors from PayPal SDK when components are not enabled for the account.
         //
-        if ($this->log !== null) {
+        // Skip 404 pages to avoid log noise from bot traffic and broken links.
+        $isNotFoundPage = ($current_page === 'page_not_found')
+            || (defined('FILENAME_PAGE_NOT_FOUND') && $current_page === FILENAME_PAGE_NOT_FOUND);
+
+        if ($this->log !== null && !$isNotFoundPage) {
             $sdk_url = $js_url . '?' . str_replace('%2C', ',', http_build_query($js_fields));
             $loggedClientId = (strlen($js_fields['client-id']) > 10)
                 ? substr($js_fields['client-id'], 0, 6) . '...' . substr($js_fields['client-id'], -4)

--- a/includes/modules/payment/paypalac.php
+++ b/includes/modules/payment/paypalac.php
@@ -64,7 +64,7 @@ class paypalac extends base
         return defined('MODULE_PAYMENT_PAYPALAC_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.3.14';
+    protected const CURRENT_VERSION = '1.3.15';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -795,6 +795,14 @@ class paypalac extends base
                             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, use_function, date_added)
                          VALUES
                             ('Cron Report Notification Email', 'MODULE_PAYMENT_PAYPALAC_CRON_REPORT_EMAIL', '', 'Optional email address used for PayPal Advanced Checkout cron summary reports. Leave blank to use store defaults.', 6, 0, NULL, NULL, now())"
+                    );
+
+                case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.15', '<'): //- Fall through from above
+                    $db->Execute(
+                        "INSERT IGNORE INTO " . TABLE_CONFIGURATION . "
+                            (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, use_function, date_added)
+                         VALUES
+                            ('Additional SDK Pages', 'MODULE_PAYMENT_PAYPALAC_SDK_PAGES', '', 'Provide a comma-separated list of additional <code>current_page_base</code> page names that should load the PayPal JS SDK. Core checkout/cart/search and all product-info handlers are always supported by default.', 6, 0, NULL, NULL, now())"
                     );
 
                 default:    //- Fall through from above
@@ -3112,6 +3120,8 @@ class paypalac extends base
 
                 ('List <var>discount</var> Order-Totals', 'MODULE_PAYMENT_PAYPALAC_DISCOUNT_OT', '', 'Identify, using a comma-separated list (intervening spaces are OK), any order-total modules &mdash; <em>other than</em> <code>ot_coupon</code>, <code>ot_gv</code> and <code>ot_group_pricing</code> &mdash; that add a <em>discount</em> element to an order.  Leave the setting as an empty string if there are none (the default).', 6, 0, NULL, NULL, now()),
 
+                ('Additional SDK Pages', 'MODULE_PAYMENT_PAYPALAC_SDK_PAGES', '', 'Provide a comma-separated list of additional <code>current_page_base</code> page names that should load the PayPal JS SDK. Core checkout/cart/search and all product-info handlers are always supported by default.', 6, 0, NULL, NULL, now()),
+
                 ('Debug Mode', 'MODULE_PAYMENT_PAYPALAC_DEBUGGING', 'Off', 'Would you like to enable debug mode?  A complete detailed log of failed transactions will be emailed to the store owner.', 6, 0, 'zen_cfg_select_option([\'Off\', \'Alerts Only\', \'Log File\', \'Log and Email\'], ', NULL, now()),
 
                 ('Cron Report Notification Email', 'MODULE_PAYMENT_PAYPALAC_CRON_REPORT_EMAIL', '', 'Optional email address used for PayPal Advanced Checkout cron summary reports. Leave blank to use store defaults.', 6, 0, NULL, NULL, now())"
@@ -3244,6 +3254,7 @@ class paypalac extends base
             'MODULE_PAYMENT_PAYPALAC_HANDLING_OT',
             'MODULE_PAYMENT_PAYPALAC_INSURANCE_OT',
             'MODULE_PAYMENT_PAYPALAC_DISCOUNT_OT',
+            'MODULE_PAYMENT_PAYPALAC_SDK_PAGES',
             'MODULE_PAYMENT_PAYPALAC_DEBUGGING',
             'MODULE_PAYMENT_PAYPALAC_CRON_REPORT_EMAIL',
         ];


### PR DESCRIPTION
### Motivation
- Reduce unnecessary PayPal JS SDK loading and logging noise on pages that don't need it and avoid logging 404/bot traffic.
- Provide store owners a configurable option to opt additional pages into PayPal SDK loading when required.

### Description
- Added `shouldLoadJsSdkForPage`, `getConfiguredSdkPages`, and `getPageNameFromConstant` helpers to `zcObserverPaypaladvcheckout` and only attach header/footer observers when the current page needs the PayPal JS SDK. 
- Filter out page-not-found and empty page names from SDK loading decisions and skip logging SDK configuration for 404 pages.
- Introduced the `MODULE_PAYMENT_PAYPALAC_SDK_PAGES` configuration key and related installer/upgrade insertion so admins can list comma-separated extra `current_page_base` names to force SDK inclusion, and wired it into the module's configuration list. 
- Bumped the module `CURRENT_VERSION` to `1.3.15` and added a database upgrade step to insert the new configuration entry during upgrades.

### Testing
- Performed PHP syntax checks (`php -l`) on modified files, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d059f830b4832582c80ee0dea26d22)