### PR TITLE
Fix penny rounding mismatch in PayPal order amount breakdown

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php
@@ -498,6 +498,34 @@ class CreatePayPalOrderRequest extends ErrorInfo
         if ($discount_total > 0) {
             $breakdown['discount'] = $this->setRateConvertedValue($discount_total);
         }
+
+        // -----
+        // Keep the amount-breakdown sum aligned with the order-total value. Tiny
+        // rounding deltas can appear when per-line taxes are rounded differently
+        // than the order-level total. Prefer adjusting tax_total by that delta so
+        // the detailed breakdown can still be sent to PayPal.
+        //
+        $breakdown_delta = (float)$amount['value'];
+        foreach ($breakdown as $name => $next_amount) {
+            $next_value = (float)$next_amount['value'];
+            if (in_array($name, ['discount', 'shipping_discount'], true)) {
+                $breakdown_delta += $next_value;
+            } else {
+                $breakdown_delta -= $next_value;
+            }
+        }
+
+        $currency_decimals = $this->amount->getCurrencyDecimals();
+        $epsilon = 1 / pow(10, $currency_decimals);
+        if (isset($breakdown['tax_total']) && abs($breakdown_delta) <= $epsilon) {
+            $breakdown['tax_total']['value'] = number_format(
+                (float)$breakdown['tax_total']['value'] + $breakdown_delta,
+                $currency_decimals,
+                '.',
+                ''
+            );
+        }
+
         $amount['breakdown'] = $breakdown;
 
         // -----


### PR DESCRIPTION
### Motivation
- Small per-line rounding differences could cause the summed amount breakdown to differ from the order total, which triggered the code path that removed items/breakdown and sent discrepancy alert emails.
- The change aims to preserve detailed breakdowns for PayPal submissions when the difference is only a tiny currency rounding delta by applying a minimal correction instead of dropping the breakdown.

### Description
- Compute a `breakdown_delta` in `CreatePayPalOrderRequest::getOrderAmountAndBreakdown` by comparing `amount['value']` to the summed breakdown components.
- If the delta is within one minor currency unit (derived from `getCurrencyDecimals()`), add the delta to `tax_total` and reformat the value to the correct decimal precision.
- Preserve and return `amount['breakdown']` so item-level and breakdown data are included in the PayPal request when the mismatch is negligible.
- All changes are contained in `includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php`.

### Testing
- Ran `php -l includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01ebf203408325910a68527b625bf6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PayPal order amount calculation logic; while the change is small, it affects totals sent to a payment provider and could impact order acceptance if misapplied.
> 
> **Overview**
> Prevents PayPal order creation from dropping `items`/`amount.breakdown` when the breakdown sum differs from the order total by a tiny rounding delta.
> 
> In `CreatePayPalOrderRequest::getOrderAmountAndBreakdown`, computes the delta between `amount['value']` and the summed breakdown (treating discounts as subtractive) and, when within one minor currency unit, applies that correction to `tax_total` (reformatted to the currency precision) before returning the breakdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a956ca9e4c5c960dafccfc689a966baff4d25aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->