### PR TITLE
Persist subscription expiration_date (v1.3.19)

### DIFF
--- a/admin/paypalac_subscriptions.php
+++ b/admin/paypalac_subscriptions.php
@@ -42,6 +42,12 @@ SubscriptionManager::ensureSchema();
 SavedCreditCardsManager::ensureSchema();
 VaultManager::ensureSchema();
 
+// One-time-ish backfill of saved-card expiration_date for active schedules.
+if (class_exists('paypalacSavedCardRecurring')) {
+    $paypalacExpiryBackfill = new paypalacSavedCardRecurring();
+    $paypalacExpiryBackfill->backfill_saved_card_expiration_dates();
+}
+
 define('FILENAME_PAYPALAC_SUBSCRIPTIONS', basename(__FILE__));
 
 if (!defined('HEADING_TITLE')) {
@@ -152,6 +158,12 @@ function paypalac_add_billing_periods(DateTimeImmutable $dt, string $period, int
  */
 function paypalac_calculate_subscription_expiry_date(array $row): ?string
 {
+    // Prefer the persisted creation-time expiration_date when present.
+    $stored = trim((string) ($row['expiration_date'] ?? ''));
+    if (paypalac_subscription_date_is_usable($stored)) {
+        return substr($stored, 0, 10);
+    }
+
     $cycles = (int) ($row['total_billing_cycles'] ?? 0);
     if ($cycles <= 0) {
         return null;
@@ -1008,6 +1020,33 @@ if ($action === 'update_subscription') {
         'last_modified' => date('Y-m-d H:i:s'),
     ];
 
+    // Keep stored expiration_date aligned with the configured billing schedule.
+    if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+        $helper = DIR_FS_CATALOG . 'includes/functions/extra_functions/paypalac_subscription_functions.php';
+        if (is_file($helper)) {
+            require_once $helper;
+        }
+    }
+    if (function_exists('paypalac_compute_subscription_expiration_date')) {
+        $startForExpiry = '';
+        foreach (['date_added', 'date_purchased'] as $startKey) {
+            $candidate = trim((string) ($subscriptionRow[$startKey] ?? ''));
+            if (paypalac_subscription_date_is_usable($candidate)) {
+                $startForExpiry = $candidate;
+                break;
+            }
+        }
+        if ($startForExpiry === '') {
+            $startForExpiry = date('Y-m-d H:i:s');
+        }
+        $updateData['expiration_date'] = paypalac_compute_subscription_expiration_date(
+            $startForExpiry,
+            $billingPeriod,
+            $billingFrequency,
+            $totalCycles
+        );
+    }
+
     if ($attributesEncoded !== '') {
         $updateData['attributes'] = $attributesEncoded;
     } else {
@@ -1117,6 +1156,16 @@ if ($action === 'update_subscription') {
                 }
                 if ($totalCycles >= 0) {
                     $scheduleSql .= ', total_billing_cycles = ' . (int) $totalCycles;
+                    $hasScheduleUpdate = true;
+                }
+                if (array_key_exists('expiration_date', $updateData)
+                    && $legacyMirror->ensure_saved_cards_recurring_expiration_date_column()
+                ) {
+                    if ($updateData['expiration_date'] === null || $updateData['expiration_date'] === '') {
+                        $scheduleSql .= ', expiration_date = NULL';
+                    } else {
+                        $scheduleSql .= ", expiration_date = '" . zen_db_input((string) $updateData['expiration_date']) . "'";
+                    }
                     $hasScheduleUpdate = true;
                 }
                 if ($hasScheduleUpdate) {

--- a/includes/classes/paypalacSavedCardRecurring.php
+++ b/includes/classes/paypalacSavedCardRecurring.php
@@ -215,12 +215,15 @@ return $this->PayPalAdvancedCheckout;
               $columns[$column] = ($result && $result->RecordCount() > 0);
               return $columns[$column];
       }
-      protected function saved_cards_recurring_has_column($column)
+      protected function saved_cards_recurring_has_column($column, $reset = false)
       {
               static $columns = array();
               $column = trim((string) $column);
               if ($column === '' || !defined('TABLE_SAVED_CREDIT_CARDS_RECURRING')) {
                       return false;
+              }
+              if ($reset) {
+                      unset($columns[$column]);
               }
               if (array_key_exists($column, $columns)) {
                       return $columns[$column];
@@ -229,6 +232,89 @@ return $this->PayPalAdvancedCheckout;
               $result = $db->Execute("SHOW COLUMNS FROM " . TABLE_SAVED_CREDIT_CARDS_RECURRING . " LIKE '" . zen_db_input($column) . "'");
               $columns[$column] = ($result && $result->RecordCount() > 0);
               return $columns[$column];
+      }
+
+      /**
+       * Ensure saved_credit_cards_recurring.expiration_date exists (null = indefinite).
+       */
+      public function ensure_saved_cards_recurring_expiration_date_column()
+      {
+              if ($this->saved_cards_recurring_has_column('expiration_date')) {
+                      return true;
+              }
+              if (!defined('TABLE_SAVED_CREDIT_CARDS_RECURRING')) {
+                      return false;
+              }
+              global $db;
+              $db->Execute(
+                      'ALTER TABLE ' . TABLE_SAVED_CREDIT_CARDS_RECURRING
+                      . ' ADD expiration_date DATE DEFAULT NULL'
+              );
+              return $this->saved_cards_recurring_has_column('expiration_date', true);
+      }
+
+      /**
+       * Backfill expiration_date for active saved-card subscriptions missing one.
+       */
+      public function backfill_saved_card_expiration_dates()
+      {
+              if (!$this->ensure_saved_cards_recurring_expiration_date_column()) {
+                      return 0;
+              }
+              if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+                      $helper = DIR_FS_CATALOG . 'includes/functions/extra_functions/paypalac_subscription_functions.php';
+                      if (is_file($helper)) {
+                              require_once $helper;
+                      }
+              }
+              if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+                      return 0;
+              }
+
+              global $db;
+              $updated = 0;
+              $orderJoin = defined('TABLE_ORDERS_PRODUCTS') && defined('TABLE_ORDERS')
+                      ? ' LEFT JOIN ' . TABLE_ORDERS_PRODUCTS . ' op ON op.orders_products_id = sccr.orders_products_id'
+                        . ' LEFT JOIN ' . TABLE_ORDERS . ' o ON o.orders_id = COALESCE(NULLIF(sccr.orders_id, 0), op.orders_id)'
+                      : '';
+              $result = $db->Execute(
+                      'SELECT sccr.saved_credit_card_recurring_id, sccr.date_added, sccr.billing_period, sccr.billing_frequency, sccr.total_billing_cycles,'
+                      . ($orderJoin !== '' ? ' o.date_purchased' : ' NULL AS date_purchased')
+                      . ' FROM ' . TABLE_SAVED_CREDIT_CARDS_RECURRING . ' sccr'
+                      . $orderJoin
+                      . ' WHERE sccr.expiration_date IS NULL'
+                      . ' AND sccr.total_billing_cycles > 0'
+                      . ' AND LOWER(sccr.status) IN (\'scheduled\',\'active\',\'pending\')'
+              );
+              while (is_object($result) && !$result->EOF) {
+                      $start = '';
+                      foreach (['date_added', 'date_purchased'] as $key) {
+                              $candidate = trim((string) ($result->fields[$key] ?? ''));
+                              if ($candidate !== '' && !str_starts_with($candidate, '0000-00-00')) {
+                                      $start = $candidate;
+                                      break;
+                              }
+                      }
+                      $expiry = $start !== ''
+                              ? paypalac_compute_subscription_expiration_date(
+                                      $start,
+                                      (string) ($result->fields['billing_period'] ?? ''),
+                                      (int) ($result->fields['billing_frequency'] ?? 0),
+                                      (int) ($result->fields['total_billing_cycles'] ?? 0)
+                              )
+                              : null;
+                      if ($expiry !== null) {
+                              $db->Execute(
+                                      'UPDATE ' . TABLE_SAVED_CREDIT_CARDS_RECURRING
+                                      . " SET expiration_date = '" . zen_db_input($expiry) . "'"
+                                      . ' WHERE saved_credit_card_recurring_id = ' . (int) $result->fields['saved_credit_card_recurring_id']
+                                      . ' AND expiration_date IS NULL'
+                              );
+                              $updated++;
+                      }
+                      $result->MoveNext();
+              }
+              return $updated;
       }
 protected function ensure_vault_manager_loaded() {
 if (!class_exists('PayPalAdvancedCheckout\\Common\\VaultManager')) {
@@ -869,6 +955,7 @@ $cardPayload = $this->build_vault_payment_source($payment_details, array('stored
                         array('fieldName' => 'total_billing_cycles', 'value' => $metadata['total_billing_cycles'], 'type' => 'integer'),
                         array('fieldName' => 'domain', 'value' => $metadata['domain'], 'type' => 'string'),
                         array('fieldName' => 'subscription_attributes_json', 'value' => $metadata['subscription_attributes_json'], 'type' => 'string'),
+                        array('fieldName' => 'date_added', 'value' => date('Y-m-d H:i:s'), 'type' => 'string'),
                 );
                 
                 // Add billing address fields if they exist
@@ -900,6 +987,32 @@ $cardPayload = $this->build_vault_payment_source($payment_details, array('stored
                 // Persist customers_id so admin subscription pages can filter by customer.
                 if (isset($metadata['customers_id']) && (int) $metadata['customers_id'] > 0) {
                         $sql_data_array[] = array('fieldName' => 'customers_id', 'value' => (int) $metadata['customers_id'], 'type' => 'integer');
+                }
+
+                // Planned end date from creation (null when total_billing_cycles is 0 / indefinite).
+                $this->ensure_saved_cards_recurring_expiration_date_column();
+                if ($this->saved_cards_recurring_has_column('expiration_date')) {
+                        if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+                                $helper = DIR_FS_CATALOG . 'includes/functions/extra_functions/paypalac_subscription_functions.php';
+                                if (is_file($helper)) {
+                                        require_once $helper;
+                                }
+                        }
+                        $expiry = null;
+                        if (function_exists('paypalac_compute_subscription_expiration_date')) {
+                                $startForExpiry = !empty($metadata['date_added'])
+                                        ? (string) $metadata['date_added']
+                                        : date('Y-m-d H:i:s');
+                                $expiry = paypalac_compute_subscription_expiration_date(
+                                        $startForExpiry,
+                                        (string) ($metadata['billing_period'] ?? ''),
+                                        (int) ($metadata['billing_frequency'] ?? 0),
+                                        (int) ($metadata['total_billing_cycles'] ?? 0)
+                                );
+                        }
+                        if ($expiry !== null) {
+                                $sql_data_array[] = array('fieldName' => 'expiration_date', 'value' => $expiry, 'type' => 'string');
+                        }
                 }
                 
                 $db->perform(TABLE_SAVED_CREDIT_CARDS_RECURRING, $sql_data_array);

--- a/includes/functions/extra_functions/paypalac_subscription_functions.php
+++ b/includes/functions/extra_functions/paypalac_subscription_functions.php
@@ -516,3 +516,83 @@ if (!function_exists('paypalac_checkout_vault_card_visible')) {
         return !empty($_SESSION['PayPalAdvancedCheckout']['save_card']);
     }
 }
+
+if (!function_exists('paypalac_add_billing_periods_to_date')) {
+    /**
+     * Add N billing-period units to a Y-m-d (or datetime) start date.
+     */
+    function paypalac_add_billing_periods_to_date(string $startDate, string $period, int $amount): ?string
+    {
+        $startDate = trim($startDate);
+        if ($startDate === '' || str_starts_with($startDate, '0000-00-00')) {
+            return null;
+        }
+
+        try {
+            $dt = new DateTimeImmutable(substr($startDate, 0, 10));
+        } catch (Exception $e) {
+            return null;
+        }
+
+        if ($amount === 0) {
+            return $dt->format('Y-m-d');
+        }
+
+        $period = strtolower(trim($period));
+        $sign = $amount >= 0 ? '+' : '-';
+        $abs = abs($amount);
+
+        switch ($period) {
+            case 'day':
+            case 'days':
+                $modified = $dt->modify($sign . $abs . ' days');
+                break;
+            case 'week':
+            case 'weeks':
+                $modified = $dt->modify($sign . $abs . ' weeks');
+                break;
+            case 'semimonth':
+                $modified = $dt->modify($sign . ($abs * 14) . ' days');
+                break;
+            case 'month':
+            case 'months':
+                $modified = $dt->modify($sign . $abs . ' months');
+                break;
+            case 'year':
+            case 'years':
+            case '':
+            default:
+                $modified = $dt->modify($sign . $abs . ' years');
+                break;
+        }
+
+        return $modified instanceof DateTimeImmutable ? $modified->format('Y-m-d') : null;
+    }
+}
+
+if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+    /**
+     * Fixed membership/subscription end date from creation (or start) + total cycles.
+     * total_billing_cycles <= 0 means indefinite → null.
+     */
+    function paypalac_compute_subscription_expiration_date(
+        ?string $startDate,
+        string $billingPeriod,
+        int $billingFrequency,
+        int $totalBillingCycles
+    ): ?string {
+        if ($totalBillingCycles <= 0) {
+            return null;
+        }
+
+        if ($billingFrequency <= 0) {
+            $billingFrequency = 1;
+        }
+
+        return paypalac_add_billing_periods_to_date(
+            (string) $startDate,
+            $billingPeriod,
+            $totalBillingCycles * $billingFrequency
+        );
+    }
+}

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SubscriptionManager.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SubscriptionManager.php
@@ -98,6 +98,8 @@ class SubscriptionManager
             }
         }
 
+        self::backfillExpirationDates();
+
         $indexes = [
             'idx_profile_id' => ['profile_id'],
             'idx_legacy_subscription' => ['legacy_subscription_id'],
@@ -207,6 +209,67 @@ class SubscriptionManager
         );
 
         return ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+    }
+
+    /**
+     * Backfill expiration_date for active-ish rows that have a finite cycle count.
+     * Uses date_added (fallback date_purchased) + (cycles * frequency) periods.
+     */
+    private static function backfillExpirationDates(): void
+    {
+        if (!self::columnExists('expiration_date')) {
+            return;
+        }
+
+        if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+            $helper = DIR_FS_CATALOG . 'includes/functions/extra_functions/paypalac_subscription_functions.php';
+            if (is_file($helper)) {
+                require_once $helper;
+            }
+        }
+        if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+            return;
+        }
+
+        global $db;
+
+        $result = $db->Execute(
+            'SELECT ps.paypal_subscription_id, ps.date_added, ps.billing_period, ps.billing_frequency, ps.total_billing_cycles,'
+            . ' o.date_purchased'
+            . ' FROM ' . TABLE_PAYPAL_SUBSCRIPTIONS . ' ps'
+            . ' LEFT JOIN ' . TABLE_ORDERS . ' o ON o.orders_id = ps.orders_id'
+            . ' WHERE ps.expiration_date IS NULL'
+            . ' AND ps.total_billing_cycles > 0'
+            . ' AND LOWER(ps.status) IN (\'active\',\'scheduled\',\'pending\',\'awaiting_vault\',\'suspended\')'
+        );
+
+        while (is_object($result) && !$result->EOF) {
+            $start = '';
+            foreach (['date_added', 'date_purchased'] as $key) {
+                $candidate = trim((string) ($result->fields[$key] ?? ''));
+                if ($candidate !== '' && !str_starts_with($candidate, '0000-00-00')) {
+                    $start = $candidate;
+                    break;
+                }
+            }
+            $expiry = $start !== ''
+                ? paypalac_compute_subscription_expiration_date(
+                    $start,
+                    (string) ($result->fields['billing_period'] ?? ''),
+                    (int) ($result->fields['billing_frequency'] ?? 0),
+                    (int) ($result->fields['total_billing_cycles'] ?? 0)
+                )
+                : null;
+            if ($expiry !== null) {
+                $db->Execute(
+                    'UPDATE ' . TABLE_PAYPAL_SUBSCRIPTIONS
+                    . " SET expiration_date = '" . zen_db_input($expiry) . "'"
+                    . ' WHERE paypal_subscription_id = ' . (int) $result->fields['paypal_subscription_id']
+                    . ' AND expiration_date IS NULL'
+                );
+            }
+            $result->MoveNext();
+        }
     }
 
     private static function indexExists(string $index): bool
@@ -319,6 +382,30 @@ class SubscriptionManager
             // as multiple records can have NULL values
             // Create empty result set (queryFactoryResult defaults to EOF = true)
             $existing = new \queryFactoryResult();
+        }
+
+        // Persist planned expiration at create/update when cycles are finite.
+        if (!array_key_exists('expiration_date', $subscriptionData)) {
+            if (!function_exists('paypalac_compute_subscription_expiration_date')) {
+                $helper = DIR_FS_CATALOG . 'includes/functions/extra_functions/paypalac_subscription_functions.php';
+                if (is_file($helper)) {
+                    require_once $helper;
+                }
+            }
+            if (function_exists('paypalac_compute_subscription_expiration_date')) {
+                $startForExpiry = (string)($subscriptionData['date_added'] ?? $now);
+                $computedExpiry = paypalac_compute_subscription_expiration_date(
+                    $startForExpiry,
+                    (string)($record['billing_period'] ?? ''),
+                    (int)($record['billing_frequency'] ?? 0),
+                    (int)($record['total_billing_cycles'] ?? 0)
+                );
+                $record['expiration_date'] = $computedExpiry;
+            }
+        } elseif ($subscriptionData['expiration_date'] === null || $subscriptionData['expiration_date'] === '') {
+            $record['expiration_date'] = null;
+        } else {
+            $record['expiration_date'] = substr((string)$subscriptionData['expiration_date'], 0, 10);
         }
 
         if ($existing->EOF) {

--- a/includes/modules/payment/paypalac.php
+++ b/includes/modules/payment/paypalac.php
@@ -64,7 +64,7 @@ class paypalac extends base
         return defined('MODULE_PAYMENT_PAYPALAC_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.3.18';
+    protected const CURRENT_VERSION = '1.3.19';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -831,6 +831,10 @@ class paypalac extends base
                 case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.18', '<'): //- Fall through from above
                     // Honor total_billing_cycles in saved-card recurring cron + show calculated expiry.
                     // No configuration schema changes required for this release.
+
+                case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.19', '<'): //- Fall through from above
+                    // Persist expiration_date on paypal_subscriptions + saved_credit_cards_recurring.
+                    // Schema is ensured at runtime via SubscriptionManager / paypalacSavedCardRecurring.
 
                 default:    //- Fall through from above
                     break;

--- a/tests/BillingCyclesLimitTest.php
+++ b/tests/BillingCyclesLimitTest.php
@@ -70,13 +70,13 @@ if (strpos($admin, 'function paypalac_subscription_next_payment_is_chargeable') 
     echo "✓ Admin helpers and Billing Details expiry display are present\n";
 }
 
-echo "\nTest 5: Module version bumped to 1.3.18...\n";
+echo "\nTest 5: Module version bumped to 1.3.19...\n";
 $module = file_get_contents($moduleFile);
-if (strpos($module, "CURRENT_VERSION = '1.3.18'") === false) {
-    echo "✗ CURRENT_VERSION was not bumped to 1.3.18\n";
+if (strpos($module, "CURRENT_VERSION = '1.3.19'") === false) {
+    echo "✗ CURRENT_VERSION was not bumped to 1.3.19\n";
     $failures++;
 } else {
-    echo "✓ CURRENT_VERSION is 1.3.18\n";
+    echo "✓ CURRENT_VERSION is 1.3.19\n";
 }
 
 echo "\n=== Summary ===\n";

--- a/tests/ExpirationDatePersistenceTest.php
+++ b/tests/ExpirationDatePersistenceTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Smoke checks for persisted subscription expiration_date support.
+ */
+
+$root = dirname(__DIR__);
+$failures = 0;
+
+function assert_true(bool $condition, string $message): void
+{
+    global $failures;
+    if ($condition) {
+        echo "✓ $message\n";
+        return;
+    }
+    echo "✗ $message\n";
+    $failures++;
+}
+
+echo "Test 1: Helper compute functions exist...\n";
+$helpers = file_get_contents($root . '/includes/functions/extra_functions/paypalac_subscription_functions.php');
+assert_true(strpos($helpers, 'function paypalac_compute_subscription_expiration_date') !== false, 'paypalac_compute_subscription_expiration_date defined');
+assert_true(strpos($helpers, 'function paypalac_add_billing_periods_to_date') !== false, 'paypalac_add_billing_periods_to_date defined');
+
+echo "\nTest 2: SCCR schedule_payment persists expiration_date + date_added...\n";
+$sccr = file_get_contents($root . '/includes/classes/paypalacSavedCardRecurring.php');
+assert_true(strpos($sccr, 'ensure_saved_cards_recurring_expiration_date_column') !== false, 'ensure column helper present');
+assert_true(strpos($sccr, 'backfill_saved_card_expiration_dates') !== false, 'backfill helper present');
+assert_true(strpos($sccr, "fieldName' => 'expiration_date'") !== false || strpos($sccr, "fieldName' => 'expiration_date\"") !== false || strpos($sccr, "'expiration_date'") !== false, 'expiration_date written on schedule');
+assert_true(strpos($sccr, "fieldName' => 'date_added'") !== false, 'date_added written on schedule');
+
+echo "\nTest 3: SubscriptionManager sets/backfills expiration_date...\n";
+$manager = file_get_contents($root . '/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SubscriptionManager.php');
+assert_true(strpos($manager, 'backfillExpirationDates') !== false, 'backfillExpirationDates present');
+assert_true(strpos($manager, "record['expiration_date']") !== false, 'logSubscription writes expiration_date');
+
+echo "\nTest 4: Admin prefers stored expiration_date...\n";
+$admin = file_get_contents($root . '/admin/paypalac_subscriptions.php');
+assert_true(strpos($admin, 'Prefer the persisted creation-time expiration_date') !== false, 'admin calculate prefers stored column');
+assert_true(strpos($admin, 'backfill_saved_card_expiration_dates') !== false, 'admin triggers SCCR backfill');
+
+echo "\nTest 5: Module version bumped to 1.3.19...\n";
+$module = file_get_contents($root . '/includes/modules/payment/paypalac.php');
+assert_true(strpos($module, "CURRENT_VERSION = '1.3.19'") !== false, 'CURRENT_VERSION is 1.3.19');
+
+echo "\nTest 6: Runtime compute math...\n";
+require_once $root . '/includes/functions/extra_functions/paypalac_subscription_functions.php';
+$expiry = paypalac_compute_subscription_expiration_date('2026-06-09', 'YEAR', 1, 1);
+assert_true($expiry === '2027-06-09', '1 year cycle from 2026-06-09 => 2027-06-09');
+$indefinite = paypalac_compute_subscription_expiration_date('2026-06-09', 'YEAR', 1, 0);
+assert_true($indefinite === null, '0 cycles => null (indefinite)');
+$five = paypalac_compute_subscription_expiration_date('2026-07-13', 'YEAR', 1, 5);
+assert_true($five === '2031-07-13', '5 year cycles from 2026-07-13 => 2031-07-13');
+
+if ($failures > 0) {
+    fwrite(STDERR, "\n$failures test(s) failed\n");
+    exit(1);
+}
+
+echo "\nAll expiration date persistence checks passed.\n";
+exit(0);


### PR DESCRIPTION
## Summary
- Persist planned `expiration_date` on `paypal_subscriptions` and `saved_credit_cards_recurring` at subscription creation (`NULL` = indefinite).
- Backfill active subscriptions; admin Expiry display prefers the stored column.
- Also set `date_added` on new SCCR schedules and bump module version to **1.3.19**.

## Test plan
- [x] `php tests/ExpirationDatePersistenceTest.php`
- [x] `php tests/BillingCyclesLimitTest.php`
- [ ] Create a finite-cycle saved-card subscription and confirm `expiration_date` is set
- [ ] Confirm indefinite (`total_billing_cycles = 0`) leaves `expiration_date` null
