### PR TITLE
Speed up admin PayPal Subscriptions list page

### DIFF
--- a/admin/paypalac_subscriptions.php
+++ b/admin/paypalac_subscriptions.php
@@ -43,9 +43,15 @@ SavedCreditCardsManager::ensureSchema();
 VaultManager::ensureSchema();
 
 // One-time-ish backfill of saved-card expiration_date for active schedules.
+// Cheap probe first: do not scan/update the whole table on every page view.
 if (class_exists('paypalacSavedCardRecurring')) {
     $paypalacExpiryBackfill = new paypalacSavedCardRecurring();
-    $paypalacExpiryBackfill->backfill_saved_card_expiration_dates();
+    if (method_exists($paypalacExpiryBackfill, 'saved_card_expiration_backfill_needed')
+        ? $paypalacExpiryBackfill->saved_card_expiration_backfill_needed()
+        : true
+    ) {
+        $paypalacExpiryBackfill->backfill_saved_card_expiration_dates();
+    }
 }
 
 define('FILENAME_PAYPALAC_SUBSCRIPTIONS', basename(__FILE__));
@@ -2101,7 +2107,6 @@ if (defined('TABLE_SAVED_CREDIT_CARDS_RECURRING')) {
     }
 
     $savedCardSubscriptions = $db->Execute($savedCardSql);
-    $savedCardCycleHelper = class_exists('paypalacSavedCardRecurring') ? new paypalacSavedCardRecurring() : null;
 
     if ($savedCardSubscriptions instanceof queryFactoryResult) {
         while (!$savedCardSubscriptions->EOF) {
@@ -2127,9 +2132,10 @@ if (defined('TABLE_SAVED_CREDIT_CARDS_RECURRING')) {
             ) {
                 $row['date_added'] = $scrFields['date_purchased'];
             }
-            $row['payments_completed'] = $savedCardCycleHelper instanceof paypalacSavedCardRecurring
-                ? $savedCardCycleHelper->count_completed_billing_cycles((int) $row['paypal_subscription_id'], $scrFields)
-                : ((int) ($scrFields['orders_id'] ?? 0) > 0 ? 1 : 0);
+            // Defer expensive orders_status_history LIKE counts until after pagination.
+            // Running count_completed_billing_cycles() for every saved-card row on
+            // large stores was the primary cause of 60s+ admin page loads.
+            $row['payments_completed'] = ((int) ($scrFields['orders_id'] ?? 0) > 0 ? 1 : 0);
             $row['sort_date'] = strtotime($row['date_added'] ?? ($scrFields['next_payment_date'] ?? 'now'));
             $allSubscriptions[] = $row;
             $savedCardSubscriptions->MoveNext();
@@ -2178,7 +2184,22 @@ $offset = ($currentPage - 1) * $currentPerPage;
 
 $subscriptionRows = array_slice($allSubscriptions, $offset, $currentPerPage);
 
+// Accurate completed-cycle counts only for the visible page (typically 10–100 rows).
+$savedCardCycleHelper = class_exists('paypalacSavedCardRecurring') ? new paypalacSavedCardRecurring() : null;
+if ($savedCardCycleHelper instanceof paypalacSavedCardRecurring) {
+    foreach ($subscriptionRows as $rowIndex => $visibleRow) {
+        if (($visibleRow['subscription_type'] ?? '') !== 'savedcard') {
+            continue;
+        }
+        $subscriptionRows[$rowIndex]['payments_completed'] = $savedCardCycleHelper->count_completed_billing_cycles(
+            (int) ($visibleRow['paypal_subscription_id'] ?? 0),
+            $visibleRow
+        );
+    }
+}
+
 $vaultCache = [];
+$savedCardOptionsCache = [];
 
 /**
  * Generate pagination URL with filters preserved
@@ -2544,61 +2565,65 @@ function paypalac_get_table_columns($tableName)
                     $subscriptionType = $row['subscription_type'] ?? 'rest';
                     $savedCardOptions = ['0' => 'None'];
                     if ($subscriptionType === 'savedcard' && $customersId > 0 && defined('TABLE_SAVED_CREDIT_CARDS') && defined('TABLE_PAYPAL_VAULT')) {
-                        $savedCardColumns = paypalac_get_table_columns(TABLE_SAVED_CREDIT_CARDS);
+                        if (!array_key_exists($customersId, $savedCardOptionsCache)) {
+                            $savedCardOptionsCache[$customersId] = ['0' => 'None'];
+                            $savedCardColumns = paypalac_get_table_columns(TABLE_SAVED_CREDIT_CARDS);
 
-                        if (!empty($savedCardColumns)) {
-                            $selectColumns = ['sc.saved_credit_card_id'];
-                            if (isset($savedCardColumns['type'])) {
-                                $selectColumns[] = 'sc.type';
-                            }
-                            if (isset($savedCardColumns['last_digits'])) {
-                                $selectColumns[] = 'sc.last_digits';
-                            }
-                            if (isset($savedCardColumns['holder_name'])) {
-                                $selectColumns[] = 'sc.holder_name';
-                            }
-                            if (isset($savedCardColumns['is_default'])) {
-                                $selectColumns[] = 'sc.is_default';
+                            if (!empty($savedCardColumns)) {
+                                $selectColumns = ['sc.saved_credit_card_id'];
+                                if (isset($savedCardColumns['type'])) {
+                                    $selectColumns[] = 'sc.type';
+                                }
+                                if (isset($savedCardColumns['last_digits'])) {
+                                    $selectColumns[] = 'sc.last_digits';
+                                }
+                                if (isset($savedCardColumns['holder_name'])) {
+                                    $selectColumns[] = 'sc.holder_name';
+                                }
+                                if (isset($savedCardColumns['is_default'])) {
+                                    $selectColumns[] = 'sc.is_default';
+                                }
+
+                                $whereConditions = ['sc.customers_id = ' . (int) $customersId, "sc.vault_id != ''"];
+                                if (isset($savedCardColumns['is_deleted'])) {
+                                    $whereConditions[] = 'sc.is_deleted = 0';
+                                }
+
+                                $orderBy = 'sc.saved_credit_card_id DESC';
+                                if (isset($savedCardColumns['is_default'])) {
+                                    $orderBy = 'sc.is_default DESC, ' . $orderBy;
+                                }
+
+                                $savedCardsQuery = $db->Execute(
+                                    'SELECT ' . implode(', ', $selectColumns)
+                                    . ' FROM ' . TABLE_SAVED_CREDIT_CARDS . ' sc'
+                                    . ' INNER JOIN ' . TABLE_PAYPAL_VAULT . ' pv ON pv.vault_id = sc.vault_id AND pv.customers_id = sc.customers_id'
+                                    . ' WHERE ' . implode(' AND ', $whereConditions)
+                                    . ' ORDER BY ' . $orderBy
+                                );
+                            } else {
+                                $savedCardsQuery = false;
                             }
 
-                            $whereConditions = ['sc.customers_id = ' . (int) $customersId, "sc.vault_id != ''"];
-                            if (isset($savedCardColumns['is_deleted'])) {
-                                $whereConditions[] = 'sc.is_deleted = 0';
+                            if ($savedCardsQuery instanceof queryFactoryResult) {
+                                while (!$savedCardsQuery->EOF) {
+                                    $cardId = (int)$savedCardsQuery->fields['saved_credit_card_id'];
+                                    $label = '#' . $cardId . ' ' . ($savedCardsQuery->fields['type'] ?? 'Card');
+                                    if (!empty($savedCardsQuery->fields['last_digits'])) {
+                                        $label .= ' ••••' . $savedCardsQuery->fields['last_digits'];
+                                    }
+                                    if (!empty($savedCardsQuery->fields['holder_name'])) {
+                                        $label .= ' - ' . $savedCardsQuery->fields['holder_name'];
+                                    }
+                                    if ((int)$savedCardsQuery->fields['is_default'] === 1) {
+                                        $label .= ' (Default)';
+                                    }
+                                    $savedCardOptionsCache[$customersId][(string)$cardId] = $label;
+                                    $savedCardsQuery->MoveNext();
+                                }
                             }
-
-                            $orderBy = 'sc.saved_credit_card_id DESC';
-                            if (isset($savedCardColumns['is_default'])) {
-                                $orderBy = 'sc.is_default DESC, ' . $orderBy;
-                            }
-
-                            $savedCardsQuery = $db->Execute(
-                                'SELECT ' . implode(', ', $selectColumns)
-                                . ' FROM ' . TABLE_SAVED_CREDIT_CARDS . ' sc'
-                                . ' INNER JOIN ' . TABLE_PAYPAL_VAULT . ' pv ON pv.vault_id = sc.vault_id AND pv.customers_id = sc.customers_id'
-                                . ' WHERE ' . implode(' AND ', $whereConditions)
-                                . ' ORDER BY ' . $orderBy
-                            );
-                        } else {
-                            $savedCardsQuery = false;
                         }
-
-                        if ($savedCardsQuery instanceof queryFactoryResult) {
-                            while (!$savedCardsQuery->EOF) {
-                                $cardId = (int)$savedCardsQuery->fields['saved_credit_card_id'];
-                                $label = '#' . $cardId . ' ' . ($savedCardsQuery->fields['type'] ?? 'Card');
-                                if (!empty($savedCardsQuery->fields['last_digits'])) {
-                                    $label .= ' ••••' . $savedCardsQuery->fields['last_digits'];
-                                }
-                                if (!empty($savedCardsQuery->fields['holder_name'])) {
-                                    $label .= ' - ' . $savedCardsQuery->fields['holder_name'];
-                                }
-                                if ((int)$savedCardsQuery->fields['is_default'] === 1) {
-                                    $label .= ' (Default)';
-                                }
-                                $savedCardOptions[(string)$cardId] = $label;
-                                $savedCardsQuery->MoveNext();
-                            }
-                        }
+                        $savedCardOptions = $savedCardOptionsCache[$customersId];
                     }
 
                     $orderLogEntries = [];

--- a/includes/classes/paypalacSavedCardRecurring.php
+++ b/includes/classes/paypalacSavedCardRecurring.php
@@ -254,10 +254,42 @@ return $this->PayPalAdvancedCheckout;
       }
 
       /**
+       * True when at least one saved-card schedule still needs an expiration_date.
+       * Used by the admin list page to skip a full-table backfill on warm loads.
+       */
+      public function saved_card_expiration_backfill_needed()
+      {
+              static $needed = null;
+              if ($needed !== null) {
+                      return $needed;
+              }
+              if (!$this->ensure_saved_cards_recurring_expiration_date_column()) {
+                      return $needed = false;
+              }
+
+              global $db;
+              $probe = $db->Execute(
+                      'SELECT saved_credit_card_recurring_id FROM ' . TABLE_SAVED_CREDIT_CARDS_RECURRING
+                      . ' WHERE expiration_date IS NULL'
+                      . ' AND total_billing_cycles > 0'
+                      . " AND LOWER(status) IN ('scheduled','active','pending')"
+                      . ' LIMIT 1'
+              );
+
+              return $needed = (is_object($probe) && !$probe->EOF);
+      }
+
+      /**
        * Backfill expiration_date for active saved-card subscriptions missing one.
        */
       public function backfill_saved_card_expiration_dates()
       {
+              static $alreadyRan = false;
+              if ($alreadyRan) {
+                      return 0;
+              }
+              $alreadyRan = true;
+
               if (!$this->ensure_saved_cards_recurring_expiration_date_column()) {
                       return 0;
               }

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SavedCreditCardsManager.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SavedCreditCardsManager.php
@@ -17,6 +17,18 @@ use function zen_db_input;
 
 class SavedCreditCardsManager
 {
+    /** @var bool Skip repeated schema work within a single request. */
+    private static bool $schemaReady = false;
+
+    /** @var array<string,bool> */
+    private static array $recurringColumnCache = [];
+
+    /** @var array<string,bool> */
+    private static array $savedCardsColumnCache = [];
+
+    /** @var array<string,bool> */
+    private static array $savedCardsIndexCache = [];
+
     /**
      * Ensure the saved credit cards tables exist for backward compatibility.
      * 
@@ -30,8 +42,13 @@ class SavedCreditCardsManager
      */
     public static function ensureSchema(): void
     {
+        if (self::$schemaReady) {
+            return;
+        }
+
         self::ensureSavedCreditCardsTable();
         self::ensureSavedCreditCardsRecurringTable();
+        self::$schemaReady = true;
     }
 
     /**
@@ -225,13 +242,17 @@ class SavedCreditCardsManager
      */
     private static function columnExists(string $column): bool
     {
+        if (isset(self::$recurringColumnCache[$column])) {
+            return self::$recurringColumnCache[$column];
+        }
+
         global $db;
 
         $result = $db->Execute(
             "SHOW COLUMNS FROM " . TABLE_SAVED_CREDIT_CARDS_RECURRING . " LIKE '" . zen_db_input($column) . "'"
         );
 
-        return ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+        return self::$recurringColumnCache[$column] = ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
     }
 
     /**
@@ -239,13 +260,17 @@ class SavedCreditCardsManager
      */
     private static function savedCreditCardsColumnExists(string $column): bool
     {
+        if (isset(self::$savedCardsColumnCache[$column])) {
+            return self::$savedCardsColumnCache[$column];
+        }
+
         global $db;
 
         $result = $db->Execute(
             "SHOW COLUMNS FROM " . TABLE_SAVED_CREDIT_CARDS . " LIKE '" . zen_db_input($column) . "'"
         );
 
-        return ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+        return self::$savedCardsColumnCache[$column] = ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
     }
 
     /**
@@ -253,12 +278,16 @@ class SavedCreditCardsManager
      */
     private static function savedCreditCardsIndexExists(string $indexName): bool
     {
+        if (isset(self::$savedCardsIndexCache[$indexName])) {
+            return self::$savedCardsIndexCache[$indexName];
+        }
+
         global $db;
 
         $result = $db->Execute(
             "SHOW INDEX FROM " . TABLE_SAVED_CREDIT_CARDS . " WHERE Key_name = '" . zen_db_input($indexName) . "'"
         );
 
-        return ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+        return self::$savedCardsIndexCache[$indexName] = ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
     }
 }

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SubscriptionManager.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SubscriptionManager.php
@@ -22,11 +22,27 @@ class SubscriptionManager
     
     private const VAULT_ID_MAX_LENGTH = 64;
 
+    /** @var bool Skip repeated schema work within a single request. */
+    private static bool $schemaReady = false;
+
+    /** @var array<string,bool> */
+    private static array $columnCache = [];
+
+    /** @var array<string,bool> */
+    private static array $indexCache = [];
+
+    /** @var bool */
+    private static bool $expirationBackfillChecked = false;
+
     /**
      * Ensure the subscription logging table exists.
      */
     public static function ensureSchema(): void
     {
+        if (self::$schemaReady) {
+            return;
+        }
+
         defined('TABLE_PAYPAL_SUBSCRIPTIONS') or define('TABLE_PAYPAL_SUBSCRIPTIONS', DB_PREFIX . 'paypal_subscriptions');
 
         global $db;
@@ -68,6 +84,7 @@ class SubscriptionManager
 
         self::ensureLegacyColumns();
         self::migrateOrdersProductsIdToNullable();
+        self::$schemaReady = true;
     }
 
     private static function ensureLegacyColumns(): void
@@ -90,15 +107,25 @@ class SubscriptionManager
             'paypal_subscription_remote_id' => "VARCHAR(64) NOT NULL DEFAULT ''",
         ];
 
+        $addedExpirationDate = false;
         foreach ($columns as $column => $definition) {
             if (!self::columnExists($column)) {
                 $db->Execute(
                     'ALTER TABLE ' . TABLE_PAYPAL_SUBSCRIPTIONS . ' ADD ' . $column . ' ' . $definition
                 );
+                self::$columnCache[$column] = true;
+                if ($column === 'expiration_date') {
+                    $addedExpirationDate = true;
+                }
             }
         }
 
-        self::backfillExpirationDates();
+        // Only scan for missing expiration dates when the column was just added or
+        // a cheap existence check finds work. Running the full backfill on every
+        // admin page load was a major contributor to multi-minute load times.
+        if ($addedExpirationDate || self::expirationBackfillNeeded()) {
+            self::backfillExpirationDates();
+        }
 
         $indexes = [
             'idx_profile_id' => ['profile_id'],
@@ -112,6 +139,7 @@ class SubscriptionManager
                 $db->Execute(
                     'ALTER TABLE ' . TABLE_PAYPAL_SUBSCRIPTIONS . ' ADD INDEX ' . $index . ' (' . implode(',', $columns) . ')'
                 );
+                self::$indexCache[$index] = true;
             }
         }
     }
@@ -202,13 +230,44 @@ class SubscriptionManager
 
     private static function columnExists(string $column): bool
     {
+        if (isset(self::$columnCache[$column])) {
+            return self::$columnCache[$column];
+        }
+
         global $db;
 
         $result = $db->Execute(
             "SHOW COLUMNS FROM " . TABLE_PAYPAL_SUBSCRIPTIONS . " LIKE '" . zen_db_input($column) . "'"
         );
 
-        return ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+        return self::$columnCache[$column] = ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+    }
+
+    /**
+     * Cheap check used to skip the full expiration backfill on warm requests.
+     */
+    private static function expirationBackfillNeeded(): bool
+    {
+        if (self::$expirationBackfillChecked) {
+            return false;
+        }
+        self::$expirationBackfillChecked = true;
+
+        if (!self::columnExists('expiration_date')) {
+            return false;
+        }
+
+        global $db;
+
+        $probe = $db->Execute(
+            'SELECT paypal_subscription_id FROM ' . TABLE_PAYPAL_SUBSCRIPTIONS
+            . ' WHERE expiration_date IS NULL'
+            . ' AND total_billing_cycles > 0'
+            . " AND LOWER(status) IN ('active','scheduled','pending','awaiting_vault','suspended')"
+            . ' LIMIT 1'
+        );
+
+        return is_object($probe) && !$probe->EOF;
     }
 
     /**
@@ -274,13 +333,17 @@ class SubscriptionManager
 
     private static function indexExists(string $index): bool
     {
+        if (isset(self::$indexCache[$index])) {
+            return self::$indexCache[$index];
+        }
+
         global $db;
 
         $result = $db->Execute(
             "SHOW INDEX FROM " . TABLE_PAYPAL_SUBSCRIPTIONS . " WHERE Key_name = '" . zen_db_input($index) . "'"
         );
 
-        return ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
+        return self::$indexCache[$index] = ($result instanceof \queryFactoryResult && $result->RecordCount() > 0);
     }
 
     /**

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/VaultManager.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/VaultManager.php
@@ -20,11 +20,18 @@ use function json_encode;
  */
 class VaultManager
 {
+    /** @var bool Skip repeated schema work within a single request. */
+    private static bool $schemaReady = false;
+
     /**
      * Ensure that the paypal vault table exists.
      */
     public static function ensureSchema(): void
     {
+        if (self::$schemaReady) {
+            return;
+        }
+
         global $db;
 
         defined('TABLE_PAYPAL_VAULT') or define('TABLE_PAYPAL_VAULT', DB_PREFIX . 'paypal_vault');
@@ -68,6 +75,8 @@ class VaultManager
                  ADD COLUMN visible TINYINT(1) NOT NULL DEFAULT 1"
             );
         }
+
+        self::$schemaReady = true;
     }
 
     /**

--- a/tests/AdminSubscriptionsListPerfTest.php
+++ b/tests/AdminSubscriptionsListPerfTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Smoke checks that the admin subscriptions list no longer counts billing cycles
+ * for every saved-card row before pagination, and that schema/backfill helpers
+ * short-circuit after the first warm check.
+ */
+
+$root = dirname(__DIR__);
+$admin = file_get_contents($root . '/admin/paypalac_subscriptions.php');
+$manager = file_get_contents($root . '/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/SubscriptionManager.php');
+$sccr = file_get_contents($root . '/includes/classes/paypalacSavedCardRecurring.php');
+
+function assert_true($cond, $msg)
+{
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: $msg\n");
+        exit(1);
+    }
+    fwrite(STDOUT, "OK: $msg\n");
+}
+
+assert_true(
+    strpos($admin, 'Defer expensive orders_status_history LIKE counts until after pagination') !== false,
+    'admin defers cycle counts until after pagination'
+);
+assert_true(
+    preg_match('/\$subscriptionRows = array_slice\(\$allSubscriptions[\s\S]*count_completed_billing_cycles/', $admin) === 1,
+    'count_completed_billing_cycles runs only on the visible page'
+);
+assert_true(
+    strpos($admin, "payments_completed'] = ((int) (\$scrFields['orders_id']") !== false,
+    'full list uses cheap orders_id placeholder for payments_completed'
+);
+assert_true(
+    strpos($manager, 'private static bool $schemaReady = false') !== false,
+    'SubscriptionManager caches ensureSchema per request'
+);
+assert_true(
+    strpos($manager, 'expirationBackfillNeeded') !== false,
+    'SubscriptionManager gates expiration backfill'
+);
+assert_true(
+    strpos($sccr, 'function saved_card_expiration_backfill_needed') !== false,
+    'saved-card backfill has cheap probe helper'
+);
+assert_true(
+    strpos($admin, 'saved_card_expiration_backfill_needed') !== false,
+    'admin page uses saved-card backfill probe'
+);
+
+fwrite(STDOUT, "\nAll AdminSubscriptionsListPerfTest checks passed.\n");


### PR DESCRIPTION
## Summary
- Defer `count_completed_billing_cycles` (leading-wildcard `LIKE` on `orders_status_history`) until after pagination so only the visible page pays that cost.
- Gate expiration-date backfills behind cheap `LIMIT 1` probes and cache `ensureSchema` / column checks per request.
- Cache per-customer saved-card option lookups while rendering the list.

## Test plan
- [ ] Open admin PayPal Subscriptions on a store with many saved-card schedules; confirm first page loads in a few seconds instead of ~1 minute.
- [ ] Confirm completed-cycle / expiry display is still correct on visible rows.
- [ ] Confirm filters, pagination, archive/unarchive, and CSV export still work.
- [ ] Run `php tests/AdminSubscriptionsListPerfTest.php` and `php tests/ExpirationDatePersistenceTest.php`.

Made with [Cursor](https://cursor.com)