### PR TITLE
RED-1839: Notify authoritative admin refund amount

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Admin/DoRefund.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Admin/DoRefund.php
@@ -7,7 +7,7 @@
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2023 Nov 16 Modified in v2.0.0 $
  *
- * Last updated: v1.3.1
+ * Last updated: v1.3.20
  */
 namespace PayPalAdvancedCheckout\Admin;
 
@@ -143,6 +143,29 @@ class DoRefund
             $payer_note;
 
         zen_update_orders_history($oID, $comments, null, $refund_status, 0);
+
+        // -----
+        // Publish the authoritative PayPal refund amount so site integrations
+        // (e.g. TaxJar) do not rely on the submitted $_POST['ppr-amount'] or
+        // the "full refund" checkbox, both of which can differ from what PayPal
+        // actually refunded for this capture.
+        //
+        global $zco_notifier;
+        if (isset($zco_notifier) && is_object($zco_notifier) && method_exists($zco_notifier, 'notify')) {
+            $zco_notifier->notify(
+                'NOTIFY_PAYPALAC_ADMIN_REFUND_COMPLETE',
+                [
+                    'orders_id' => $oID,
+                    'capture_txn_id' => (string)$_POST['capture_txn_id'],
+                    'refund_txn_id' => (string)($refund_response['id'] ?? ''),
+                    'refund_amount' => (float)($refund_response['amount']['value'] ?? 0),
+                    'currency_code' => (string)($refund_response['amount']['currency_code'] ?? $capture_currency),
+                    'full_refund_requested' => $full_refund,
+                    'is_subscription_cycle' => $is_subscription_cycle,
+                    'refund_response' => $refund_response,
+                ]
+            );
+        }
 
         $messageStack->add_session(sprintf(MODULE_PAYMENT_PAYPALAC_REFUND_COMPLETE, $amount_refunded), 'success');
     }

--- a/includes/modules/payment/paypalac.php
+++ b/includes/modules/payment/paypalac.php
@@ -64,7 +64,7 @@ class paypalac extends base
         return defined('MODULE_PAYMENT_PAYPALAC_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.3.19';
+    protected const CURRENT_VERSION = '1.3.20';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -835,6 +835,10 @@ class paypalac extends base
                 case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.19', '<'): //- Fall through from above
                     // Persist expiration_date on paypal_subscriptions + saved_credit_cards_recurring.
                     // Schema is ensured at runtime via SubscriptionManager / paypalacSavedCardRecurring.
+
+                case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.20', '<'): //- Fall through from above
+                    // Notify site observers of the authoritative PayPal refund amount
+                    // after a successful admin refund (NOTIFY_PAYPALAC_ADMIN_REFUND_COMPLETE).
 
                 default:    //- Fall through from above
                     break;


### PR DESCRIPTION
## Summary
- After a successful admin refund, fire `NOTIFY_PAYPALAC_ADMIN_REFUND_COMPLETE` with the PayPal response amount, currency, and txn ids.
- Bump module version to 1.3.20 so sites can upgrade and pick up the notifier.

## Test plan
- [ ] Refund a capture via admin orders page (partial and full-checkbox).
- [ ] Confirm success message still shows PayPal refund amount.
- [ ] Confirm observers receive `NOTIFY_PAYPALAC_ADMIN_REFUND_COMPLETE` with `refund_amount` matching PayPal (not necessarily `$_POST['ppr-amount']`).