### PR TITLE
Require PayPal capture rows before checkout recovery

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/CheckoutRecovery.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/CheckoutRecovery.php
@@ -141,15 +141,7 @@ class CheckoutRecovery
             }
         }
 
-        $order_status = strtoupper((string)($paypal_order['status'] ?? ''));
-        if (in_array($order_status, ['REFUNDED', 'PARTIALLY_REFUNDED', 'VOIDED', 'FAILED', 'DENIED'], true)) {
-            return false;
-        }
-        if ($should_capture) {
-            return in_array($order_status, ['COMPLETED', 'CAPTURED'], true);
-        }
-
-        return $order_status === 'COMPLETED';
+        return false;
     }
 
     public static function shouldKeepExistingOrderWhenLiveLookupFails(string $cached_status): bool

--- a/tests/CheckoutRecoveryAlreadyCapturedTest.php
+++ b/tests/CheckoutRecoveryAlreadyCapturedTest.php
@@ -127,6 +127,7 @@ $authorized_order = [
 ];
 checkout_recovery_assert(!CheckoutRecovery::paypalOrderHasSuccessfulPaymentAction($approved_order, true), 'APPROVED order is not a successful capture');
 checkout_recovery_assert(CheckoutRecovery::paypalOrderHasSuccessfulPaymentAction($completed_order, true), 'COMPLETED capture is successful');
+checkout_recovery_assert(!CheckoutRecovery::paypalOrderHasSuccessfulPaymentAction(['id' => 'EMPTY', 'status' => 'COMPLETED'], true), 'COMPLETED without payment rows is not success');
 checkout_recovery_assert(CheckoutRecovery::paypalOrderHasSuccessfulPaymentAction($authorized_order, false), 'CREATED authorization is successful');
 checkout_recovery_assert(CheckoutRecovery::paypalOrderIsReusable($approved_order), 'APPROVED leftover is reusable');
 $refunded_order = [


### PR DESCRIPTION
## Summary
- Treat a PayPal order as paid only when a capture or authorization row exists with a successful status.
- Prevents `before_process` from reading a missing `captures[0]` after a COMPLETED GET with no payment payload.

## Test plan
- [x] `php tests/CheckoutRecoveryAlreadyCapturedTest.php`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment-success detection used during duplicate-capture recovery and reuse checks; incorrect behavior could block valid recoveries or change when orders are retried, but scope is limited to PayPal Advanced Checkout recovery helpers.
> 
> **Overview**
> **PayPal Advanced Checkout recovery** no longer treats a live order as successfully paid based only on top-level order status (`COMPLETED`, `CAPTURED`, etc.) when `purchase_units` payment rows are missing.
> 
> `CheckoutRecovery::paypalOrderHasSuccessfulPaymentAction` now returns **true** only when a capture or authorization entry exists with an acceptable row status; if the payments array is empty or inconclusive, it returns **false** instead of falling back to order-level status. That stops recovery paths (e.g. after `ORDER_ALREADY_CAPTURED`) from assuming payment succeeded when PayPal returns `COMPLETED` without a `captures` payload—avoiding downstream access to a missing `captures[0]` during checkout `before_process`.
> 
> A regression test asserts that a `COMPLETED` order with no payment rows is **not** considered a successful capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe707b3ca69118beab545bf0e0e8291444c2bad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->