### PR TITLE
Store PayPal wallet return order snapshot in session

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/ppac_listener.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/ppac_listener.php
@@ -30,6 +30,7 @@ if (!defined('MODULE_PAYMENT_PAYPALAC_STATUS') || MODULE_PAYMENT_PAYPALAC_STATUS
 require DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/ppacAutoload.php';
 
 use PayPalAdvancedCheckout\Api\PayPalAdvancedCheckoutApi;
+use PayPalAdvancedCheckout\Common\CheckoutRecovery;
 use PayPalAdvancedCheckout\Common\Logger;
 use PayPalAdvancedCheckout\Compatibility\Language as LanguageCompatibility;
 
@@ -181,8 +182,16 @@ if ($op === '3ds_return') {
 // the base payment module "knows" that the payment-confirmation (or creation) at PayPal
 // has been completed.
 //
-$_SESSION['PayPalAdvancedCheckout']['Order']['status'] = $order_status['status'];
 if ($op === 'return') {
+    $_SESSION['PayPalAdvancedCheckout']['Order'] = array_replace(
+        $_SESSION['PayPalAdvancedCheckout']['Order'],
+        CheckoutRecovery::sessionOrderFromPayPalResponse(
+            $order_status,
+            (string)($_SESSION['PayPalAdvancedCheckout']['Order']['guid'] ?? ''),
+            (string)($_SESSION['PayPalAdvancedCheckout']['Order']['payment_source'] ?? 'paypal'),
+            (array)($_SESSION['PayPalAdvancedCheckout']['Order']['amount_mismatch'] ?? [])
+        )
+    );
     $_SESSION['PayPalAdvancedCheckout']['Order']['wallet_payment_confirmed'] = true;
 } else {
     $_SESSION['PayPalAdvancedCheckout']['Order']['3DS_response'] = $_SESSION['PayPalAdvancedCheckout']['Order']['PayerAction']['ccInfo'];

--- a/ppac_listener.php
+++ b/ppac_listener.php
@@ -30,6 +30,7 @@ if (!defined('MODULE_PAYMENT_PAYPALAC_STATUS') || MODULE_PAYMENT_PAYPALAC_STATUS
 require DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/ppacAutoload.php';
 
 use PayPalAdvancedCheckout\Api\PayPalAdvancedCheckoutApi;
+use PayPalAdvancedCheckout\Common\CheckoutRecovery;
 use PayPalAdvancedCheckout\Common\Logger;
 use PayPalAdvancedCheckout\Compatibility\Language as LanguageCompatibility;
 
@@ -255,6 +256,15 @@ if ($op === '3ds_return') {
 //
 $_SESSION['PayPalAdvancedCheckout']['Order']['status'] = $order_status['status'];
 if ($op === 'return') {
+    $_SESSION['PayPalAdvancedCheckout']['Order'] = array_replace(
+        $_SESSION['PayPalAdvancedCheckout']['Order'],
+        CheckoutRecovery::sessionOrderFromPayPalResponse(
+            $order_status,
+            (string)($_SESSION['PayPalAdvancedCheckout']['Order']['guid'] ?? ''),
+            (string)($_SESSION['PayPalAdvancedCheckout']['Order']['payment_source'] ?? 'paypal'),
+            (array)($_SESSION['PayPalAdvancedCheckout']['Order']['amount_mismatch'] ?? [])
+        )
+    );
     $_SESSION['PayPalAdvancedCheckout']['Order']['wallet_payment_confirmed'] = true;
 } else {
     $_SESSION['PayPalAdvancedCheckout']['Order']['3DS_response'] = $_SESSION['PayPalAdvancedCheckout']['Order']['PayerAction']['ccInfo'];


### PR DESCRIPTION
## Summary
- After PayPal wallet return, persist the full order payment snapshot in session via CheckoutRecovery::sessionOrderFromPayPalResponse().
- Complements CheckoutRecovery on main by avoiding an unnecessary failed capture attempt when Pay in 3 already settled the order.

## Test plan
- [ ] Pay in 3 wallet return completes without ORDER_ALREADY_CAPTURED admin alert
- [ ] Session Order.current contains captures after ppac_listener return

Made with [Cursor](https://cursor.com)