### PR TITLE
NX-615108: Pay Later configurable amount limits and SDK isolation

### DIFF
--- a/docs/PayPal Advanced Checkout/readme.html
+++ b/docs/PayPal Advanced Checkout/readme.html
@@ -225,6 +225,7 @@
             <li>Confirm the primary <code>paypalac</code> module is installed with valid API credentials.</li>
             <li>Go to <strong>Modules &rarr; Payment</strong>, select <strong>PayPal Pay Later</strong>, and click <strong>Install</strong>.</li>
             <li>Enable the module and set its sort order. The module reads the parent API settings automatically.</li>
+            <li>Set <strong>PayLater Minimum Order Amount</strong> and <strong>PayLater Maximum Order Amount</strong> to hide Pay Later outside the range PayPal will accept. Defaults are 30 and 2000. PayPal&rsquo;s published Pay in 4 range is typically $30&ndash;$2,000 USD, but a merchant account can have a lower maximum; use the values PayPal support gives you if they differ.</li>
             <li>Configure the <strong>PayLater Messaging</strong> setting to control where promotional messaging appears on your storefront.</li>
           </ol>
           <h5>How it works</h5>
@@ -276,7 +277,7 @@ class zcObserverMyPaylaterCustomizer extends base
 }</code></pre>
           <h5>Troubleshooting</h5>
           <ul class="bodyList">
-            <li><strong>Pay Later button not appearing:</strong> Verify the store currency is USD, GBP, EUR, or AUD. Ensure the main PayPal Advanced Checkout module is installed and has valid credentials. Check that the Pay Later module is enabled.</li>
+            <li><strong>Pay Later button not appearing:</strong> Verify the store currency is USD, GBP, EUR, or AUD. Ensure the main PayPal Advanced Checkout module is installed and has valid credentials. Check that the Pay Later module is enabled. Confirm the order total is between the configured minimum and maximum amounts.</li>
             <li><strong>Messaging not appearing:</strong> Verify the store currency is USD, GBP, EUR, or AUD. Check that the <strong>PayLater Messaging</strong> setting includes the current page type.</li>
             <li><strong>Messaging in wrong location:</strong> Add a <code>&lt;div id="paypal-message-container"&gt;&lt;/div&gt;</code> element where you want the messaging to appear, or use the observer hook for custom selectors.</li>
             <li><strong>Customer not eligible:</strong> PayPal determines eligibility based on factors like location, order amount, and customer&rsquo;s PayPal account history. The button will automatically hide for ineligible customers.</li>

--- a/includes/languages/english/modules/payment/lang.paypalac_paylater.php
+++ b/includes/languages/english/modules/payment/lang.paypalac_paylater.php
@@ -11,6 +11,8 @@ $define = [
     'MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_PAYER_ACTION' => 'An additional action is required to complete your Pay Later payment. Please choose another payment method or contact us for assistance.',
     'MODULE_PAYMENT_PAYPALAC_PAYING_WITH_PAYLATER' => 'Paying with PayPal Pay Later',
     'MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE' => 'Pay Later is temporarily unavailable. Please try again or choose a different payment method.',
+    'MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_BELOW_MINIMUM' => 'Pay Later is available for orders of %s %s or more.',
+    'MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_ABOVE_MAXIMUM' => 'Pay Later is available for orders up to %s %s.',
 ];
 
 return $define;

--- a/includes/languages/english/modules/payment/paypalac_paylater.php
+++ b/includes/languages/english/modules/payment/paypalac_paylater.php
@@ -13,3 +13,5 @@ define('MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_CONFIRM_FAILED', 'We were unable 
 define('MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_PAYER_ACTION', 'An additional action is required to complete your Pay Later payment. Please choose another payment method or contact us for assistance.');
 define('MODULE_PAYMENT_PAYPALAC_PAYING_WITH_PAYLATER', 'Paying with PayPal Pay Later');
 define('MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE', 'Pay Later is temporarily unavailable. Please try again or choose a different payment method.');
+define('MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_BELOW_MINIMUM', 'Pay Later is available for orders of %s %s or more.');
+define('MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_ABOVE_MAXIMUM', 'Pay Later is available for orders up to %s %s.');

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
@@ -19,20 +19,18 @@
     var WALLET_BUTTON_MIN_WIDTH = '200px';
     var WALLET_BUTTON_MAX_WIDTH = '320px';
 
-    var sharedSdkLoader = window.paypalacSdkLoaderState || { key: null, promise: null };
-    window.paypalacSdkLoaderState = sharedSdkLoader;
+    var sharedSdkLoader = window.paypalacPaylaterSdkLoaderState || { key: null, promise: null };
+    window.paypalacPaylaterSdkLoaderState = sharedSdkLoader;
 
-    /**
-     * Get CSP nonce from existing script tags if available.
-     * This helps comply with Content Security Policy when loading external scripts.
-     */
-    /**
-     * Get the PayPal SDK namespace.
-     * The header observer may load the SDK with data-namespace="PayPalSDK",
-     * placing it at window.PayPalSDK instead of window.paypal.
-     */
     function getPayPalNamespace() {
-        return window.paypal || window.PayPalSDK;
+        var candidates = [window.paypalacPaylater, window.paypal, window.PayPalSDK];
+        for (var i = 0; i < candidates.length; i++) {
+            if (candidates[i] && typeof candidates[i].Buttons === 'function') {
+                return candidates[i];
+            }
+        }
+
+        return window.paypalacPaylater || window.paypal || window.PayPalSDK;
     }
 
     function normalizeWalletContainer(element) {
@@ -59,6 +57,103 @@
         element.style.maxWidth = WALLET_BUTTON_MAX_WIDTH;
         element.style.minWidth = WALLET_BUTTON_MIN_WIDTH;
         element.style.boxSizing = 'border-box';
+    }
+
+    function parseAmountValue(value) {
+        if (value === null || typeof value === 'undefined') {
+            return null;
+        }
+
+        if (typeof value === 'number' && isFinite(value)) {
+            return value;
+        }
+
+        var normalized = String(value).replace(/[^0-9.,-]/g, '').replace(/,/g, '');
+        if (normalized === '' || normalized === '-' || normalized === '.') {
+            return null;
+        }
+
+        var parsed = parseFloat(normalized);
+        return isFinite(parsed) ? parsed : null;
+    }
+
+    function getOrderTotalFromPage() {
+        var totalElement = document.getElementById('ottotal');
+        if (!totalElement) {
+            return null;
+        }
+
+        return parseAmountValue(totalElement.textContent || totalElement.innerText || '');
+    }
+
+    function configHasKnownOrderTotal(config) {
+        return config && config.orderTotal !== null && typeof config.orderTotal !== 'undefined' && config.orderTotal !== '';
+    }
+
+    function getEffectiveOrderTotal(config) {
+        if (configHasKnownOrderTotal(config)) {
+            return parseAmountValue(config.orderTotal);
+        }
+
+        return getOrderTotalFromPage();
+    }
+
+    function isWithinPayLaterLimits(total, config) {
+        if (total === null || !config) {
+            return true;
+        }
+
+        var minAmount = parseAmountValue(config.minAmount);
+        var maxAmount = parseAmountValue(config.maxAmount);
+
+        if (minAmount !== null && total < minAmount) {
+            return false;
+        }
+
+        if (maxAmount !== null && maxAmount > 0 && total > maxAmount) {
+            return false;
+        }
+
+        return true;
+    }
+
+    function shouldHidePayLaterForConfig(config) {
+        if (!config) {
+            return true;
+        }
+
+        if (config.success === false) {
+            return true;
+        }
+
+        if (config.withinLimits === false) {
+            return true;
+        }
+
+        var orderTotal = getEffectiveOrderTotal(config);
+        if (orderTotal !== null && !isWithinPayLaterLimits(orderTotal, config)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    function logPayLaterLimitState(config, source) {
+        if (!config) {
+            return;
+        }
+
+        var orderTotal = getEffectiveOrderTotal(config);
+        console.log(
+            'Pay Later limit check (' + (source || 'unknown') + '):',
+            {
+                minAmount: config.minAmount,
+                maxAmount: config.maxAmount,
+                orderTotal: orderTotal,
+                withinLimits: config.withinLimits,
+                shouldHide: shouldHidePayLaterForConfig(config)
+            }
+        );
     }
 
     function getCspNonce() {
@@ -226,6 +321,12 @@
     }
 
     function rerenderPaylaterButton() {
+        if (sdkState.config && shouldHidePayLaterForConfig(sdkState.config)) {
+            logPayLaterLimitState(sdkState.config, 'rerender');
+            hidePaymentMethodContainer();
+            return;
+        }
+
         if (typeof window.paypalacPaylaterRender === 'function') {
             window.paypalacPaylaterRender();
         }
@@ -297,61 +398,61 @@
         return [config.clientId, currency, merchantId, environment, 'paylater'].join('|');
     }
 
+    function namespaceHasPayLaterButtons(ns) {
+        return !!(ns && typeof ns.Buttons === 'function' && ns.FUNDING && ns.FUNDING.PAYLATER);
+    }
+
     function loadPayPalSdk(config) {
         if (!config || !config.clientId) {
             return Promise.reject(new Error('Missing clientId for PayPal SDK load'));
         }
 
         var desiredKey = buildSdkKey(config);
-        // Also detect the header-loaded SDK script (id="PayPalJSSDK") which does
-        // not carry the data-paypal-sdk attribute but uses data-namespace="PayPalSDK".
-        var existingScript = document.querySelector('script[data-paypal-sdk="true"]') || document.getElementById('PayPalJSSDK');
+        var existingPaylaterScript = document.querySelector('script[data-paypal-sdk="paylater"]');
+        var isSandbox = (config.environment || '') === 'sandbox';
 
-        // Check if the SDK is already available under either namespace
-        var paypalNs = getPayPalNamespace();
-        if (sharedSdkLoader.promise && sharedSdkLoader.key === desiredKey && paypalNs && typeof paypalNs.Buttons === 'function') {
-            return sharedSdkLoader.promise.then(function () { return getPayPalNamespace(); });
+        var paypalNs = window.paypalacPaylater;
+        if (sharedSdkLoader.promise && sharedSdkLoader.key === desiredKey && namespaceHasPayLaterButtons(paypalNs)) {
+            return sharedSdkLoader.promise.then(function () { return window.paypalacPaylater || getPayPalNamespace(); });
         }
 
-        // SDK already fully loaded (e.g. by the header observer) but sharedSdkLoader
-        // was never set (different script context).  Reuse it immediately.
-        if (paypalNs && typeof paypalNs.Buttons === 'function') {
+        if (namespaceHasPayLaterButtons(window.paypalacPaylater)) {
             sharedSdkLoader.key = desiredKey;
-            sharedSdkLoader.promise = Promise.resolve(paypalNs);
+            sharedSdkLoader.promise = Promise.resolve(window.paypalacPaylater);
             return sharedSdkLoader.promise;
         }
 
-        if (existingScript) {
-            var matchesClient = existingScript.src.indexOf(encodeURIComponent(config.clientId)) !== -1;
-            var matchesCurrency = existingScript.src.indexOf('currency=' + encodeURIComponent(config.currency || 'USD')) !== -1;
-            var matchesMerchant = !config.merchantId || existingScript.src.indexOf('merchant-id=' + encodeURIComponent(config.merchantId)) !== -1;
-            var matchesPaylater = existingScript.src.indexOf('enable-funding=paylater') !== -1;
+        if (existingPaylaterScript) {
+            var matchesClient = existingPaylaterScript.src.indexOf(encodeURIComponent(config.clientId)) !== -1;
+            var matchesCurrency = existingPaylaterScript.src.indexOf('currency=' + encodeURIComponent(config.currency || 'USD')) !== -1;
+            var matchesMerchant = !config.merchantId || existingPaylaterScript.src.indexOf('merchant-id=' + encodeURIComponent(config.merchantId)) !== -1;
+            var matchesPaylater = existingPaylaterScript.src.indexOf('enable-funding=paylater') !== -1;
+            var matchesButtons = existingPaylaterScript.src.indexOf('components=buttons') !== -1
+                || existingPaylaterScript.src.indexOf('components=') === -1
+                || /components=[^&]*buttons/.test(existingPaylaterScript.src);
 
-            if (matchesClient && matchesCurrency && matchesMerchant && matchesPaylater) {
-                var loadedNs = getPayPalNamespace();
-                if (loadedNs && typeof loadedNs.Buttons === 'function') {
+            if (matchesClient && matchesCurrency && matchesMerchant && matchesPaylater && matchesButtons) {
+                if (namespaceHasPayLaterButtons(window.paypalacPaylater)) {
                     sharedSdkLoader.key = desiredKey;
-                    sharedSdkLoader.promise = Promise.resolve(loadedNs);
+                    sharedSdkLoader.promise = Promise.resolve(window.paypalacPaylater);
                     return sharedSdkLoader.promise;
                 }
 
                 return new Promise(function (resolve, reject) {
-                    existingScript.addEventListener('load', function () {
-                        existingScript.dataset.loaded = 'true';
+                    existingPaylaterScript.addEventListener('load', function () {
+                        existingPaylaterScript.dataset.loaded = 'true';
                         sharedSdkLoader.key = desiredKey;
-                        resolve(getPayPalNamespace());
+                        resolve(window.paypalacPaylater || getPayPalNamespace());
                     });
-                    existingScript.addEventListener('error', function (event) {
+                    existingPaylaterScript.addEventListener('error', function (event) {
                         sharedSdkLoader.promise = null;
                         reject(event);
                     });
                 });
             }
 
-            // Only remove the script if it was one we created (has data-paypal-sdk),
-            // never remove the header-loaded SDK.
-            if (existingScript.dataset && existingScript.dataset.paypalSdk === 'true') {
-                existingScript.parentNode.removeChild(existingScript);
+            if (existingPaylaterScript.parentNode) {
+                existingPaylaterScript.parentNode.removeChild(existingPaylaterScript);
             }
         }
 
@@ -360,7 +461,10 @@
             + '&enable-funding=paylater'
             + '&currency=' + encodeURIComponent(config.currency || 'USD');
 
-        // Only include merchant-id if it's a valid PayPal merchant ID (alphanumeric, typically 13 chars).
+        if (isSandbox) {
+            query += '&buyer-country=US';
+        }
+
         if (config.merchantId && /^[A-Z0-9]{5,20}$/i.test(config.merchantId)) {
             query += '&merchant-id=' + encodeURIComponent(config.merchantId);
         }
@@ -368,15 +472,15 @@
         sharedSdkLoader.promise = new Promise(function(resolve, reject) {
             var script = document.createElement('script');
             script.src = 'https://www.paypal.com/sdk/js' + query;
-            script.dataset.paypalSdk = 'true';
+            script.dataset.paypalSdk = 'paylater';
             script.dataset.loaded = 'false';
-            
-            // Add CSP nonce if available
+            script.setAttribute('data-namespace', 'paypalacPaylater');
+
             var nonce = getCspNonce();
             if (nonce) {
                 script.setAttribute('nonce', nonce);
             }
-            
+
             script.onload = function () {
                 script.dataset.loaded = 'true';
                 sharedSdkLoader.key = desiredKey;
@@ -386,7 +490,7 @@
                     merchantId: config.merchantId,
                     environment: config.environment
                 };
-                resolve(getPayPalNamespace());
+                resolve(window.paypalacPaylater || getPayPalNamespace());
             };
             script.onerror = function (event) {
                 sharedSdkLoader.promise = null;
@@ -422,6 +526,12 @@
                 return null;
             }
 
+            if (shouldHidePayLaterForConfig(config)) {
+                logPayLaterLimitState(config, 'config');
+                hidePaymentMethodContainer();
+                return null;
+            }
+
             sdkState.config = config;
             return loadPayPalSdk(config).then(function (paypal) {
                 if (currentRenderRequestId !== renderRequestId) {
@@ -443,7 +553,12 @@
                                 sdkState.config = orderConfig;
                                 return orderConfig.orderID;
                             }
-                            throw new Error('Unable to create Pay Later order');
+
+                            var failureMessage = (orderConfig && orderConfig.message)
+                                ? orderConfig.message
+                                : 'Unable to create Pay Later order';
+                            console.error('Pay Later order creation failed', orderConfig || {});
+                            throw new Error(failureMessage);
                         });
                     },
                     onClick: function () {
@@ -521,7 +636,13 @@
             }
 
             clearTimeout(rerenderTimeout);
-            rerenderTimeout = setTimeout(rerenderPaylaterButton, 50);
+            rerenderTimeout = setTimeout(function() {
+                var pageTotal = getOrderTotalFromPage();
+                if (sdkState.config) {
+                    sdkState.config.orderTotal = pageTotal;
+                }
+                rerenderPaylaterButton();
+            }, 50);
         });
 
         observer.observe(totalElement, { childList: true, subtree: true, characterData: true });

--- a/includes/modules/payment/paypalac_paylater.php
+++ b/includes/modules/payment/paypalac_paylater.php
@@ -52,7 +52,7 @@ class paypalac_paylater extends base
         return defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.0.0';
+    protected const CURRENT_VERSION = '1.1.0';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -61,6 +61,10 @@ class paypalac_paylater extends base
 
     // Pay Later is available in these currencies only
     protected const SUPPORTED_CURRENCIES = ['USD', 'GBP', 'EUR', 'AUD'];
+
+    // PayPal Pay in 4 published range for USD merchants; admin may override per account.
+    protected const DEFAULT_MIN_AMOUNT = 30.0;
+    protected const DEFAULT_MAX_AMOUNT = 2000.0;
 
     public string $code;
     public string $title;
@@ -270,6 +274,40 @@ class paypalac_paylater extends base
                     ('PayLater Messaging', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_MESSAGING', 'Checkout, Shopping Cart, Product Pages', 'On which pages should PayPal PayLater messaging be displayed? (It will automatically not be displayed in regions where it is not available. Only available in USD, GBP, EUR, AUD.) When enabled, it will show the lower installment-based pricing for the presented product or cart amount. This may accelerate buying decisions.<br><b>Default: All</b>', 6, 0, 'zen_cfg_select_multioption([''Checkout'', ''Shopping Cart'', ''Product Pages'', ''Product Listings and Search Results''], ', NULL, now())"
             );
         }
+
+        $amount_limit_keys = [
+            [
+                'title' => 'PayLater Minimum Order Amount',
+                'key' => 'MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT',
+                'value' => (string)self::DEFAULT_MIN_AMOUNT,
+                'description' => 'Hide Pay Later when the order total is below this amount (in the customer\'s checkout currency). PayPal\'s Pay in 4 product is typically $30–$2,000 USD, but limits can vary by merchant account and buyer eligibility.<br><b>Default: 30</b>',
+                'sort_order' => 1,
+            ],
+            [
+                'title' => 'PayLater Maximum Order Amount',
+                'key' => 'MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT',
+                'value' => (string)self::DEFAULT_MAX_AMOUNT,
+                'description' => 'Hide Pay Later when the order total exceeds this amount (in the customer\'s checkout currency). PayPal may enforce a lower account-specific maximum; set this to match guidance from PayPal support if needed.<br><b>Default: 2000</b>',
+                'sort_order' => 2,
+            ],
+        ];
+
+        foreach ($amount_limit_keys as $amount_limit) {
+            $amount_limit_check = $db->Execute(
+                "SELECT configuration_id
+                   FROM " . TABLE_CONFIGURATION . "
+                  WHERE configuration_key = '" . zen_db_input($amount_limit['key']) . "'
+                  LIMIT 1"
+            );
+            if ($amount_limit_check->EOF) {
+                $db->Execute(
+                    "INSERT INTO " . TABLE_CONFIGURATION . "
+                        (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, use_function, date_added)
+                     VALUES
+                        ('" . zen_db_input($amount_limit['title']) . "', '" . zen_db_input($amount_limit['key']) . "', '" . zen_db_input($amount_limit['value']) . "', '" . zen_db_input($amount_limit['description']) . "', 6, " . (int)$amount_limit['sort_order'] . ", NULL, NULL, now())"
+                );
+            }
+        }
         
         // Record the current version of the payment module into its database configuration setting
         $db->Execute(
@@ -367,6 +405,158 @@ class paypalac_paylater extends base
                 $this->enabled = false;
             }
         }
+
+        if ($this->enabled === true && !$this->isOrderTotalWithinPayLaterLimits()) {
+            $this->enabled = false;
+        }
+    }
+
+    protected function getConfiguredMinAmount(): float
+    {
+        if (!defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT')) {
+            return self::DEFAULT_MIN_AMOUNT;
+        }
+
+        $min_amount = (float)MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT;
+        return ($min_amount >= 0) ? $min_amount : self::DEFAULT_MIN_AMOUNT;
+    }
+
+    protected function getConfiguredMaxAmount(): float
+    {
+        if (!defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT')) {
+            return self::DEFAULT_MAX_AMOUNT;
+        }
+
+        $max_amount = (float)MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT;
+        return ($max_amount > 0) ? $max_amount : self::DEFAULT_MAX_AMOUNT;
+    }
+
+    protected function getOrderTotalForLimitCheck(): ?float
+    {
+        global $order;
+
+        if (isset($order) && is_object($order) && isset($order->info['total']) && is_numeric($order->info['total'])) {
+            return (float)$order->info['total'];
+        }
+
+        return null;
+    }
+
+    protected function orderTotalWithinConfiguredLimits(float $order_total): bool
+    {
+        $min_amount = $this->getConfiguredMinAmount();
+        $max_amount = $this->getConfiguredMaxAmount();
+
+        if ($max_amount > 0 && $max_amount < $min_amount) {
+            $max_amount = $min_amount;
+        }
+
+        if ($order_total < $min_amount) {
+            return false;
+        }
+
+        if ($max_amount > 0 && $order_total > $max_amount) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function isOrderTotalWithinPayLaterLimits(?float $order_total = null): bool
+    {
+        if ($order_total === null) {
+            $order_total = $this->getOrderTotalForLimitCheck();
+        }
+
+        if ($order_total === null) {
+            return true;
+        }
+
+        $within_limits = $this->orderTotalWithinConfiguredLimits($order_total);
+        if ($within_limits === false) {
+            $min_amount = $this->getConfiguredMinAmount();
+            $max_amount = $this->getConfiguredMaxAmount();
+            if ($order_total < $min_amount) {
+                $this->log->write(
+                    'Pay Later: Module disabled because order total ' . number_format($order_total, 2, '.', '') .
+                    ' is below configured minimum ' . number_format($min_amount, 2, '.', '') . '.'
+                );
+            } elseif ($max_amount > 0 && $order_total > $max_amount) {
+                $this->log->write(
+                    'Pay Later: Module disabled because order total ' . number_format($order_total, 2, '.', '') .
+                    ' exceeds configured maximum ' . number_format($max_amount, 2, '.', '') . '.'
+                );
+            }
+        }
+
+        return $within_limits;
+    }
+
+    protected function getPayLaterLimitContext(?float $order_total = null): array
+    {
+        if ($order_total === null) {
+            $order_total = $this->getOrderTotalForLimitCheck();
+        }
+
+        return [
+            'minAmount' => $this->getConfiguredMinAmount(),
+            'maxAmount' => $this->getConfiguredMaxAmount(),
+            'orderTotal' => $order_total,
+            'withinLimits' => ($order_total === null) ? true : $this->orderTotalWithinConfiguredLimits($order_total),
+            'currency' => $_SESSION['currency'] ?? DEFAULT_CURRENCY,
+        ];
+    }
+
+    protected function getPayLaterAmountLimitMessage(string $reason): string
+    {
+        $limits = $this->getPayLaterLimitContext();
+        $currency = $limits['currency'];
+        $order_total = $limits['orderTotal'];
+
+        if ($reason === 'below_minimum') {
+            return sprintf(
+                MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_BELOW_MINIMUM ?? 'Pay Later is available for orders of %s %s or more.',
+                number_format($limits['minAmount'], 2, '.', ''),
+                $currency
+            );
+        }
+
+        if ($reason === 'above_maximum') {
+            return sprintf(
+                MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_ABOVE_MAXIMUM ?? 'Pay Later is available for orders up to %s %s.',
+                number_format($limits['maxAmount'], 2, '.', ''),
+                $currency
+            );
+        }
+
+        if ($reason === 'amount_out_of_range' && $order_total !== null) {
+            if ((float)$order_total < (float)$limits['minAmount']) {
+                return $this->getPayLaterAmountLimitMessage('below_minimum');
+            }
+            if ((float)$limits['maxAmount'] > 0 && (float)$order_total > (float)$limits['maxAmount']) {
+                return $this->getPayLaterAmountLimitMessage('above_maximum');
+            }
+        }
+
+        return MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE ?? 'Unable to start Pay Later. Please try again.';
+    }
+
+    protected function getPayLaterLimitFailureReason(array $limit_context): string
+    {
+        if ((float)($limit_context['orderTotal'] ?? 0) < (float)$limit_context['minAmount']) {
+            return 'below_minimum';
+        }
+
+        return 'above_maximum';
+    }
+
+    protected function buildPayLaterAmountLimitFailure(string $reason): array
+    {
+        return [
+            'success' => false,
+            'message' => $this->getPayLaterAmountLimitMessage($reason),
+            'reason' => $reason,
+        ] + $this->getPayLaterLimitContext();
     }
 
     /**
@@ -526,13 +716,34 @@ class paypalac_paylater extends base
             return ['success' => false, 'message' => MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE ?? 'Unable to start Pay Later. Please try again.'];
         }
 
+        $limit_context = $this->getPayLaterLimitContext();
+        $this->log->write(
+            "Pay Later ajaxGetWalletConfig limits:\n" .
+            "  - Min: " . number_format($limit_context['minAmount'], 2, '.', '') . "\n" .
+            "  - Max: " . number_format($limit_context['maxAmount'], 2, '.', '') . "\n" .
+            "  - Order Total: " . ($limit_context['orderTotal'] === null ? '(unknown)' : number_format((float)$limit_context['orderTotal'], 2, '.', '')) . "\n" .
+            "  - Within Limits: " . ($limit_context['withinLimits'] ? 'Yes' : 'No'),
+            true,
+            'after'
+        );
+
+        if ($limit_context['withinLimits'] === false) {
+            $reason = $this->getPayLaterLimitFailureReason($limit_context);
+
+            return $this->buildPayLaterAmountLimitFailure($reason) + [
+                'clientId' => $client_id,
+                'intent' => $intent,
+                'environment' => MODULE_PAYMENT_PAYPALAC_SERVER,
+            ];
+        }
+
         return [
             'success' => true,
             'clientId' => $client_id,
             'currency' => $_SESSION['currency'] ?? 'USD',
             'intent' => $intent,
             'environment' => MODULE_PAYMENT_PAYPALAC_SERVER,
-        ];
+        ] + $limit_context;
     }
 
     public function ajaxCreateWalletOrder(): array
@@ -630,8 +841,29 @@ class paypalac_paylater extends base
             return ['success' => false, 'message' => MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE ?? 'Unable to start Pay Later. Please try again.'];
         }
 
+        $limit_context = $this->getPayLaterLimitContext();
+        if ($limit_context['withinLimits'] === false) {
+            return $this->buildPayLaterAmountLimitFailure($this->getPayLaterLimitFailureReason($limit_context));
+        }
+
         if ($this->createPayPalOrder($ppac_type, false) === false) {
-            return ['success' => false];
+            $message = MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE ?? 'Unable to start Pay Later. Please try again.';
+            $error_info = $this->getErrorInfo()->getErrorInfo();
+            $error_message = trim((string)($error_info['message'] ?? ''));
+            $debug_id = trim((string)($error_info['debug_id'] ?? ''));
+            if ($error_message !== '' || $debug_id !== '') {
+                $this->log->write(
+                    'Pay Later buildWalletAjaxResponse order creation failed: ' .
+                    ($error_message !== '' ? $error_message : 'n/a') .
+                    ($debug_id !== '' ? ' (debug_id: ' . $debug_id . ')' : '')
+                );
+            }
+
+            return [
+                'success' => false,
+                'message' => $message,
+                'reason' => 'order_creation_failed',
+            ] + $limit_context;
         }
 
         $orderData = $_SESSION['PayPalAdvancedCheckout']['Order'] ?? [];
@@ -644,7 +876,7 @@ class paypalac_paylater extends base
             'currency' => $current['currency_code'] ?? ($_SESSION['currency'] ?? ''),
             'intent' => $orderData['current']['intent'] ?? $intent,
             'clientId' => $client_id,
-        ];
+        ] + $limit_context;
     }
 
     public function setMessageAndRedirect(string $error_message, string $redirect_page, bool $log_only = false)
@@ -910,6 +1142,8 @@ class paypalac_paylater extends base
              VALUES
                 ('Module Version', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_VERSION', '$current_version', 'Currently-installed module version.', 6, 0, 'zen_cfg_read_only(', NULL, now()),
                 ('Enable PayPal Pay Later?', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_STATUS', 'False', 'Do you want to enable PayPal Pay Later payments? Pay Later allows customers to pay in installments (Pay in 4) or with monthly financing. Available in USD, GBP, EUR, and AUD only.', 6, 0, 'zen_cfg_select_option([''True'', ''False'', ''Retired''], ', NULL, now()),
+                ('PayLater Minimum Order Amount', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT', '30', 'Hide Pay Later when the order total is below this amount (in the customer''s checkout currency). PayPal''s Pay in 4 product is typically $30–$2,000 USD, but limits can vary by merchant account and buyer eligibility.<br><b>Default: 30</b>', 6, 1, NULL, NULL, now()),
+                ('PayLater Maximum Order Amount', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT', '2000', 'Hide Pay Later when the order total exceeds this amount (in the customer''s checkout currency). PayPal may enforce a lower account-specific maximum; set this to match guidance from PayPal support if needed.<br><b>Default: 2000</b>', 6, 2, NULL, NULL, now()),
                 ('PayLater Messaging', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_MESSAGING', 'Checkout, Shopping Cart, Product Pages', 'On which pages should PayPal PayLater messaging be displayed? (It will automatically not be displayed in regions where it is not available. Only available in USD, GBP, EUR, AUD.) When enabled, it will show the lower installment-based pricing for the presented product or cart amount. This may accelerate buying decisions.<br><b>Default: All</b>', 6, 0, 'zen_cfg_select_multioption([''Checkout'', ''Shopping Cart'', ''Product Pages'', ''Product Listings and Search Results''], ', NULL, now()),
                 ('Sort order of display.', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_SORT_ORDER', '0', 'Sort order of display. Lowest is displayed first.', 6, 0, NULL, NULL, now()),
                 ('Payment Zone', 'MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE', '0', 'If a zone is selected, only enable this payment method for that zone.', 6, 0, 'zen_cfg_pull_down_zone_classes(', 'zen_get_zone_class_title', now())" 
@@ -948,6 +1182,8 @@ class paypalac_paylater extends base
         return [
             'MODULE_PAYMENT_PAYPALAC_PAYLATER_VERSION',
             'MODULE_PAYMENT_PAYPALAC_PAYLATER_STATUS',
+            'MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT',
+            'MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT',
             'MODULE_PAYMENT_PAYPALAC_PAYLATER_MESSAGING',
             'MODULE_PAYMENT_PAYPALAC_PAYLATER_SORT_ORDER',
             'MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE',

--- a/ppac_wallet.php
+++ b/ppac_wallet.php
@@ -83,7 +83,8 @@ if (!$hasValidCart && !$configOnly) {
 // The observer's getLastOrderValues() fallback will still retrieve basic totals
 // from $order->info even if the full order_total processing encounters issues.
 //
-// Skip order initialization for config_only requests since they don't need it.
+// Skip order initialization for config_only requests, except Pay Later which
+// needs the current order total to enforce min/max amount limits.
 //
 global $order, $order_total_modules;
 
@@ -97,7 +98,7 @@ if (!function_exists('ppac_wallet_sanitize_error_message')) {
     }
 }
 
-if (!$configOnly && $hasValidCart) {
+if ($hasValidCart && (!$configOnly || $wallet === 'paylater')) {
     $ppacWalletDebugEnabled = defined('MODULE_PAYMENT_PAYPALAC_DEBUGGING')
         && strpos((string)MODULE_PAYMENT_PAYPALAC_DEBUGGING, 'Log') !== false;
 
@@ -123,7 +124,7 @@ try {
     }
     // Do not exit - allow the request to continue with the fallback mechanism
 }
-} // end if (!$configOnly && $hasValidCart)
+}
 
 $moduleMap = [
     'google_pay' => 'paypalac_googlepay',

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Pay Later min/max amount limits and SDK isolation.
+ *
+ * @copyright Copyright 2026 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+declare(strict_types=1);
+
+$failures = 0;
+
+$paylaterPhp = file_get_contents(__DIR__ . '/../includes/modules/payment/paypalac_paylater.php');
+$paylaterJs = file_get_contents(__DIR__ . '/../includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js');
+$walletPhp = file_get_contents(__DIR__ . '/../ppac_wallet.php');
+$langPhp = file_get_contents(__DIR__ . '/../includes/languages/english/modules/payment/lang.paypalac_paylater.php');
+
+fwrite(STDOUT, "Testing Pay Later amount limits\n");
+fwrite(STDOUT, "================================\n\n");
+
+if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.0'") === false) {
+    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.0 so tableCheckup inserts the new amount keys\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.0\n");
+}
+
+foreach ([
+    'MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT',
+    'MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT',
+] as $key) {
+    if (strpos($paylaterPhp, $key) === false) {
+        fwrite(STDERR, "FAIL: paypalac_paylater.php should define $key\n");
+        $failures++;
+    } else {
+        fwrite(STDOUT, "  ✓ $key is present\n");
+    }
+}
+
+if (strpos($paylaterPhp, "DEFAULT_MAX_AMOUNT = 2000.0") === false) {
+    fwrite(STDERR, "FAIL: default Pay Later maximum should be 2000\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Default maximum amount is 2000\n");
+}
+
+if (strpos($paylaterPhp, "DEFAULT_MIN_AMOUNT = 30.0") === false) {
+    fwrite(STDERR, "FAIL: default Pay Later minimum should be 30\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Default minimum amount is 30\n");
+}
+
+if (strpos($paylaterPhp, 'isOrderTotalWithinPayLaterLimits') === false
+    || strpos($paylaterPhp, 'orderTotalWithinConfiguredLimits') === false
+) {
+    fwrite(STDERR, "FAIL: paypalac_paylater.php should enforce configured amount limits\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Amount limit helpers are present\n");
+}
+
+if (strpos($paylaterPhp, "'MODULE_PAYMENT_PAYPALAC_PAYLATER_MIN_AMOUNT'") === false
+    || strpos($paylaterPhp, "'MODULE_PAYMENT_PAYPALAC_PAYLATER_MAX_AMOUNT'") === false
+) {
+    fwrite(STDERR, "FAIL: keys() should expose the min/max amount settings\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Admin keys() includes min/max amount settings\n");
+}
+
+if (strpos($paylaterPhp, 'reason') === false || strpos($paylaterPhp, 'order_creation_failed') === false) {
+    fwrite(STDERR, "FAIL: wallet order creation failures should return a reason and message\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Wallet order creation failures return a reason\n");
+}
+
+if (strpos($langPhp, 'MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_BELOW_MINIMUM') === false
+    || strpos($langPhp, 'MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_ABOVE_MAXIMUM') === false
+) {
+    fwrite(STDERR, "FAIL: language file should include min/max amount error strings\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Language strings for amount limits are present\n");
+}
+
+if (strpos($walletPhp, '$wallet === \'paylater\'') === false) {
+    fwrite(STDERR, "FAIL: ppac_wallet.php should initialize order totals for Pay Later config_only requests\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later config_only requests initialize order totals\n");
+}
+
+if (strpos($paylaterJs, 'function shouldHidePayLaterForConfig') === false
+    || strpos($paylaterJs, 'function isWithinPayLaterLimits') === false
+) {
+    fwrite(STDERR, "FAIL: Pay Later JS should hide the button outside configured amount limits\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later JS has client-side amount limit checks\n");
+}
+
+if (strpos($paylaterJs, 'data-namespace') === false
+    || strpos($paylaterJs, 'paypalacPaylater') === false
+    || strpos($paylaterJs, "dataset.paypalSdk = 'paylater'") === false
+) {
+    fwrite(STDERR, "FAIL: Pay Later JS should load a dedicated SDK namespace instead of removing #PayPalJSSDK\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later JS loads a dedicated paypalacPaylater SDK namespace\n");
+}
+
+if (preg_match('/existingScript\.parentNode\.removeChild\(existingScript\)/', $paylaterJs)) {
+    fwrite(STDERR, "FAIL: Pay Later JS should not remove the shared header PayPal SDK script\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later JS does not remove the header PayPal SDK\n");
+}
+
+if (strpos($paylaterJs, 'enable-funding=paylater') === false) {
+    fwrite(STDERR, "FAIL: Pay Later JS should still request enable-funding=paylater\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later JS still enables Pay Later funding\n");
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "\n✗ FAILED: $failures test(s) failed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "\n✓ Pay Later amount limits test passed.\n");


### PR DESCRIPTION
## Summary
- Add admin-configurable Pay Later minimum (default 30) and maximum (default 2000) order amounts so the payment method hides outside PayPal''s acceptable range.
- Enforce limits server-side in `update_status`, wallet config/order AJAX, and client-side as the checkout total changes.
- Load Pay Later in a dedicated `paypalacPaylater` SDK namespace instead of removing the header `#PayPalJSSDK` script, which could break eligible carts under the maximum.
- Return clearer wallet order-creation failures with logged PayPal debug details.

## Test plan
- [x] `php tests/PayLaterAmountLimitsTest.php`
- [x] `php tests/WalletIneligiblePaymentHidingTest.php`
- [ ] Admin visit to Modules > Payment > PayPal Pay Later runs tableCheckup and shows min/max settings
- [ ] Checkout cart > $2000 hides Pay Later
- [ ] Checkout cart between $30 and $2000 shows Pay Later and completes sandbox payment
- [ ] Browser console shows no PayPal SDK reload errors on checkout payment page
