### PR TITLE
NX-615108: Hide theme Pay Later radio circle and reuse header SDK

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
@@ -261,6 +261,10 @@
         var moduleRadio = document.getElementById('pmt-paypalac_paylater');
         if (moduleRadio) {
             moduleRadio.classList.add('paypalac-wallet-radio-hidden');
+            var control = moduleRadio.closest('.custom-radio, .custom-control, .nmx-radio');
+            if (control) {
+                control.classList.add('paypalac-wallet-radio-hidden-control');
+            }
             return true;
         }
 
@@ -395,11 +399,53 @@
         var currency = config.currency || 'USD';
         var merchantId = config.merchantId || '';
         var environment = config.environment || 'sandbox';
-        return [config.clientId, currency, merchantId, environment, 'paylater'].join('|');
+        var intent = normalizeSdkIntent(config.intent);
+        return [config.clientId, currency, merchantId, environment, intent, 'paylater'].join('|');
+    }
+
+    function normalizeSdkIntent(intent) {
+        var value = String(intent || 'capture').toLowerCase();
+        return (value === 'authorize') ? 'authorize' : 'capture';
+    }
+
+    function getScriptSdkIntent(script) {
+        if (!script || !script.src) {
+            return 'capture';
+        }
+
+        var match = script.src.match(/[?&]intent=([^&]*)/i);
+        if (!match || match[1] === '') {
+            return 'capture';
+        }
+
+        return normalizeSdkIntent(decodeURIComponent(match[1]));
+    }
+
+    function findHeaderPayPalScript() {
+        return document.getElementById('PayPalJSSDK')
+            || document.querySelector('script[data-namespace="PayPalSDK"]')
+            || document.querySelector('script[src*="paypal.com/sdk/js"]');
     }
 
     function namespaceHasPayLaterButtons(ns) {
         return !!(ns && typeof ns.Buttons === 'function' && ns.FUNDING && ns.FUNDING.PAYLATER);
+    }
+
+    function findReusablePayLaterNamespace(config) {
+        var desiredIntent = normalizeSdkIntent(config && config.intent);
+        var headerScript = findHeaderPayPalScript();
+        var headerIntentMatches = getScriptSdkIntent(headerScript) === desiredIntent;
+        var headerNs = window.PayPalSDK || window.paypal;
+
+        if (headerIntentMatches && namespaceHasPayLaterButtons(headerNs)) {
+            return headerNs;
+        }
+
+        if (namespaceHasPayLaterButtons(window.paypalacPaylater)) {
+            return window.paypalacPaylater;
+        }
+
+        return null;
     }
 
     function loadPayPalSdk(config) {
@@ -410,6 +456,13 @@
         var desiredKey = buildSdkKey(config);
         var existingPaylaterScript = document.querySelector('script[data-paypal-sdk="paylater"]');
         var isSandbox = (config.environment || '') === 'sandbox';
+        var reusableNs = findReusablePayLaterNamespace(config);
+
+        if (reusableNs) {
+            sharedSdkLoader.key = desiredKey;
+            sharedSdkLoader.promise = Promise.resolve(reusableNs);
+            return sharedSdkLoader.promise;
+        }
 
         var paypalNs = window.paypalacPaylater;
         if (sharedSdkLoader.promise && sharedSdkLoader.key === desiredKey && namespaceHasPayLaterButtons(paypalNs)) {
@@ -430,8 +483,9 @@
             var matchesButtons = existingPaylaterScript.src.indexOf('components=buttons') !== -1
                 || existingPaylaterScript.src.indexOf('components=') === -1
                 || /components=[^&]*buttons/.test(existingPaylaterScript.src);
+            var matchesIntent = getScriptSdkIntent(existingPaylaterScript) === normalizeSdkIntent(config.intent);
 
-            if (matchesClient && matchesCurrency && matchesMerchant && matchesPaylater && matchesButtons) {
+            if (matchesClient && matchesCurrency && matchesMerchant && matchesPaylater && matchesButtons && matchesIntent) {
                 if (namespaceHasPayLaterButtons(window.paypalacPaylater)) {
                     sharedSdkLoader.key = desiredKey;
                     sharedSdkLoader.promise = Promise.resolve(window.paypalacPaylater);
@@ -459,6 +513,7 @@
         var query = '?client-id=' + encodeURIComponent(config.clientId)
             + '&components=buttons'
             + '&enable-funding=paylater'
+            + '&intent=' + encodeURIComponent(normalizeSdkIntent(config.intent))
             + '&currency=' + encodeURIComponent(config.currency || 'USD');
 
         if (isSandbox) {

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/paypalac.css
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/paypalac.css
@@ -108,6 +108,20 @@
     border: 0 !important;
 }
 
+/*
+ * Bootstrap/custom-radio themes draw the visible circle on label::before
+ * and already hide the real input with opacity:0. Clipping the input
+ * therefore leaves the fake radio on screen. Hide that decoration too.
+ */
+.paypalac-wallet-radio-hidden-control {
+    padding-left: 0 !important;
+}
+.paypalac-wallet-radio-hidden-control > label::before,
+.paypalac-wallet-radio-hidden-control > label::after {
+    display: none !important;
+    content: none !important;
+}
+
 .paypalac-wallet-label-hidden {
     position: absolute !important;
     width: 1px !important;

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -125,6 +125,15 @@ if (strpos($paylaterJs, 'enable-funding=paylater') === false) {
     fwrite(STDOUT, "  ✓ Pay Later JS still enables Pay Later funding\n");
 }
 
+if (strpos($paylaterJs, 'findReusablePayLaterNamespace') === false
+    || strpos($paylaterJs, "'&intent='") === false
+) {
+    fwrite(STDERR, "FAIL: Pay Later JS should reuse the header SDK when it already has Pay Later, and pass intent when loading its own copy\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later JS reuses the header SDK and matches intent\n");
+}
+
 if ($failures > 0) {
     fwrite(STDERR, "\n✗ FAILED: $failures test(s) failed\n");
     exit(1);

--- a/tests/PayLaterServerConfirmationAndRadioUiTest.php
+++ b/tests/PayLaterServerConfirmationAndRadioUiTest.php
@@ -42,6 +42,13 @@ if ($hideModuleRadioCallCount < 2) {
     echo "✓ Pay Later JS invokes hideModuleRadio() during normal rendering (found {$hideModuleRadioCallCount} call sites)\n";
 }
 
+if (strpos($jsContent, 'paypalac-wallet-radio-hidden-control') === false) {
+    $testPassed = false;
+    $errors[] = "hideModuleRadio() must mark the theme custom-radio wrapper so label::before (the visible circle) is hidden, not just the already-invisible input.";
+} else {
+    echo "✓ Pay Later JS marks the custom-radio wrapper so the visible fake radio is hidden\n";
+}
+
 // Test 2: The label text is NOT hidden by default (only the radio), so the
 // shopper still sees "PayPal Pay Later" for context next to the button.
 if (strpos($jsContent, 'Keep the mock radio button visible') !== false) {

--- a/tests/WalletModuleRadioHiddenTest.php
+++ b/tests/WalletModuleRadioHiddenTest.php
@@ -168,6 +168,15 @@ if (strpos($cssContent, 'clip-path: inset') === false) {
     echo "✓ Hidden class uses clip-path for modern browsers\n";
 }
 
+if (strpos($cssContent, 'paypalac-wallet-radio-hidden-control') === false
+    || strpos($cssContent, 'label::before') === false
+) {
+    $testPassed = false;
+    $errors[] = "CSS should hide custom-radio label::before/::after when the wallet radio wrapper is marked hidden";
+} else {
+    echo "✓ CSS hides theme custom-radio decoration for wallet methods\n";
+}
+
 // Summary
 echo "\n";
 if ($testPassed) {


### PR DESCRIPTION
## Summary
- The visible Pay Later "radio" on this theme is `label::before`, not the input (the input is already `opacity: 0`). Clipping the input left the circle on screen. `hideModuleRadio()` now marks the `.custom-radio` wrapper and CSS hides `label::before` / `label::after`.
- Pay in 4 showing "unavailable" on eligible carts: Pay Later was loading a second buttons-only SDK without `intent`, which fights the header SDK. Reuse the header `PayPalSDK` when it already has Pay Later + matching intent; if a dedicated copy is still needed, pass `intent`.

Not promoting this to production until you confirm. Ticket 615108 will not be updated until then.

## Test plan
- [x] Plugin tests: PayLaterAmountLimits, PayLaterServerConfirmationAndRadioUi, WalletModuleRadioHidden, WalletIneligiblePaymentHiding
- [ ] On checkout with a cart between $30 and $2000: no native radio circle next to Pay Later; yellow Pay Later / Pay in 4 button is eligible (not "unavailable")
