### PR TITLE
Stop hard declines from reusing a declined PayPal order GUID

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/CheckoutRecovery.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Common/CheckoutRecovery.php
@@ -178,6 +178,11 @@ class CheckoutRecovery
         return in_array($status, self::PRESERVE_ORDER_STATUSES, true);
     }
 
+    public static function noteFailedPaymentAttempt(): void
+    {
+        $_SESSION['PayPalAdvancedCheckout']['FailedPaymentAttempts'] = (int)($_SESSION['PayPalAdvancedCheckout']['FailedPaymentAttempts'] ?? 0) + 1;
+    }
+
     public static function sessionOrderFromPayPalResponse(
         array $paypal_order,
         string $order_guid,

--- a/includes/modules/payment/paypal/paypal_common.php
+++ b/includes/modules/payment/paypal/paypal_common.php
@@ -947,6 +947,9 @@ class PayPalCommon {
         );
         if ($response === false) {
             $error_info = $ppr->getErrorInfo();
+            if (CheckoutRecovery::isHardPaymentFailure($error_info)) {
+                CheckoutRecovery::noteFailedPaymentAttempt();
+            }
             $keep_order = CheckoutRecovery::shouldPreservePayPalOrderOnError()
                 && !CheckoutRecovery::isHardPaymentFailure($error_info);
             if ($keep_order === false) {

--- a/includes/modules/payment/paypalac.php
+++ b/includes/modules/payment/paypalac.php
@@ -2106,6 +2106,9 @@ class paypalac extends base
             $recovered = $this->paypalCommon->recoverExistingPayPalOrderAfterDuplicateCreate($this->ppr, $this->log, $error_info);
             if ($recovered === false) {
                 $this->errorInfo->copyErrorInfo($error_info);
+                if (CheckoutRecovery::isDuplicatePaymentActionIssue($error_info)) {
+                    CheckoutRecovery::noteFailedPaymentAttempt();
+                }
                 return false;
             }
             $order_response = $recovered;

--- a/includes/modules/payment/paypalac.php
+++ b/includes/modules/payment/paypalac.php
@@ -65,7 +65,7 @@ class paypalac extends base
         return defined('MODULE_PAYMENT_PAYPALAC_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.3.22';
+    protected const CURRENT_VERSION = '1.3.23';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -848,6 +848,10 @@ class paypalac extends base
                 case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.22', '<'): //- Fall through from above
                     // Recover APPROVED leftover PayPal orders after ORDER_ALREADY_CAPTURED
                     // instead of alerting and wiping the checkout session.
+
+                case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.23', '<'): //- Fall through from above
+                    // Hard payment declines bump FailedPaymentAttempts so createOrderGuid
+                    // mints a new PayPal order instead of reusing a declined APPROVED leftover.
 
                 default:    //- Fall through from above
                     break;
@@ -2174,6 +2178,7 @@ class paypalac extends base
     protected function createOrderGuid(\order $order, string $ppac_type, array $order_info = [], array $order_total_changes = []): string
     {
         $_SESSION['PayPalAdvancedCheckout']['CompletedOrders'] = $_SESSION['PayPalAdvancedCheckout']['CompletedOrders'] ?? 0;
+        $_SESSION['PayPalAdvancedCheckout']['FailedPaymentAttempts'] = $_SESSION['PayPalAdvancedCheckout']['FailedPaymentAttempts'] ?? 0;
         unset($order->info['ip_address']);
 
         $effective_total = isset($order_info['total']) && is_numeric($order_info['total'])
@@ -2209,6 +2214,7 @@ class paypalac extends base
             . json_encode($order)
             . ($_SESSION['securityToken'] ?? '')
             . $_SESSION['PayPalAdvancedCheckout']['CompletedOrders']
+            . $_SESSION['PayPalAdvancedCheckout']['FailedPaymentAttempts']
             . json_encode($financial_signature);
         if ($ppac_type !== 'paypal') {
             $hash_data .= json_encode($this->ccInfo);
@@ -2921,6 +2927,9 @@ class paypalac extends base
         if ($this->errorInfo->hasErrorInfo()) {
             $error_info_for_preserve = $this->errorInfo->getErrorInfo();
             $log_message .= "\n" . Logger::logJSON($error_info_for_preserve);
+            if (CheckoutRecovery::isHardPaymentFailure($error_info_for_preserve)) {
+                CheckoutRecovery::noteFailedPaymentAttempt();
+            }
             $this->errorInfo->reset();
         }
         $this->log->write($log_message);

--- a/tests/CheckoutRecoveryAlreadyCapturedTest.php
+++ b/tests/CheckoutRecoveryAlreadyCapturedTest.php
@@ -85,7 +85,9 @@ checkout_recovery_assert(CheckoutRecovery::isDuplicatePaymentActionIssue($captur
 checkout_recovery_assert(CheckoutRecovery::isDuplicatePaymentActionIssue($authorized_error), 'ORDER_ALREADY_AUTHORIZED is a duplicate issue');
 checkout_recovery_assert(!CheckoutRecovery::isDuplicatePaymentActionIssue($declined_error), 'INSTRUMENT_DECLINED is not a duplicate issue');
 checkout_recovery_assert(!CheckoutRecovery::isHardPaymentFailure($captured_error), 'ORDER_ALREADY_CAPTURED is not a hard decline');
-checkout_recovery_assert(CheckoutRecovery::isHardPaymentFailure($declined_error), 'INSTRUMENT_DECLINED is a hard payment failure');
+checkout_recovery_assert(CheckoutRecovery::paymentActionRequestId('guid-123', true) === 'guid-123-capture', 'capture Request-Id is distinct from create GUID');
+checkout_recovery_assert(CheckoutRecovery::paymentActionRequestId('guid-123', false) === 'guid-123-authorize', 'authorize Request-Id is distinct from create GUID');
+checkout_recovery_assert(CheckoutRecovery::paymentActionRequestId('guid-123', true) !== 'guid-123', 'capture must never reuse the create-order Request-Id');
 
 echo "\nTest 4: Successful payment detection and APPROVED leftover retry\n";
 $approved_order = [
@@ -195,12 +197,12 @@ checkout_recovery_assert(
     'paypalac preserves recoverable PayPal orders on redirect'
 );
 checkout_recovery_assert(
-    str_contains($paypalac, "CURRENT_VERSION = '1.3.22'"),
-    'CURRENT_VERSION is 1.3.22'
+    str_contains($paypalac, "CURRENT_VERSION = '1.3.23'"),
+    'CURRENT_VERSION is 1.3.23'
 );
 checkout_recovery_assert(
-    str_contains($paypalac, "case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.22', '<')"),
-    'tableCheckup includes 1.3.22 fall-through'
+    str_contains($paypalac, "case version_compare(MODULE_PAYMENT_PAYPALAC_VERSION, '1.3.23', '<')"),
+    'tableCheckup includes 1.3.23 fall-through'
 );
 checkout_recovery_assert(
     str_contains($common, 'CheckoutRecovery::paymentActionRequestId'),


### PR DESCRIPTION
## Summary
- After hard payment declines (`INSTRUMENT_DECLINED`), bump `FailedPaymentAttempts` into the create-order GUID so retries mint a fresh PayPal order instead of reusing a declined APPROVED leftover.
- Keep capture/authorize Request-Ids distinct from create (`-capture` / `-authorize`); bump to 1.3.23.

## Test plan
- [x] `php tests/CheckoutRecoveryAlreadyCapturedTest.php`
- [ ] Wallet capture log line uses Request-Id ending in `-capture`
- [ ] Declined capture then retry creates a new PayPal order GUID
