### PR TITLE
NX-615108: Match Pay Later checkout to PayPal radio and Confirm Order

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
@@ -257,6 +257,95 @@
         }
     }
 
+    function isPaylaterSelected() {
+        var moduleRadio = document.getElementById('pmt-paypalac_paylater');
+        return !!(moduleRadio && moduleRadio.checked);
+    }
+
+    function isPaylaterApproved() {
+        var statusField = document.getElementById('paypalac-paylater-status');
+        return !!(statusField && statusField.value === 'approved');
+    }
+
+    function shouldStartPayLaterApproval() {
+        return isPaylaterSelected() && !isPaylaterApproved() && !checkoutSubmitting;
+    }
+
+    function getPaylaterButtonElement() {
+        var container = document.getElementById('paypalac-paylater-button');
+        if (!container) {
+            return null;
+        }
+
+        return container.querySelector('.paypal-button')
+            || container.querySelector('[data-funding-source="paylater"]')
+            || container.querySelector('[role="link"]')
+            || container.querySelector('iframe');
+    }
+
+    function triggerPaylaterButtonClick() {
+        selectPaylaterRadio();
+        var button = getPaylaterButtonElement();
+        if (!button) {
+            return false;
+        }
+
+        try {
+            button.click();
+            return true;
+        } catch (error) {
+            console.warn('Unable to start Pay Later from Confirm Order', error);
+            return false;
+        }
+    }
+
+    function wrapSubmitCheckout() {
+        if (typeof window.submitCheckout !== 'function' || window.submitCheckout.__paypalacPaylaterWrapped) {
+            return;
+        }
+
+        var originalSubmitCheckout = window.submitCheckout;
+        function wrappedSubmitCheckout() {
+            if (shouldStartPayLaterApproval()) {
+                releaseCheckoutOverlay();
+                if (!triggerPaylaterButtonClick()) {
+                    renderPaylaterButton();
+                }
+                return false;
+            }
+
+            return originalSubmitCheckout.apply(this, arguments);
+        }
+        wrappedSubmitCheckout.__paypalacPaylaterWrapped = true;
+        window.submitCheckout = wrappedSubmitCheckout;
+    }
+
+    function releaseCheckoutOverlay() {
+        if (typeof jQuery !== 'undefined' && typeof jQuery.unblockUI === 'function') {
+            jQuery.unblockUI();
+        }
+    }
+
+    function interceptPaylaterCheckoutSubmit(event) {
+        if (!shouldStartPayLaterApproval()) {
+            return;
+        }
+
+        if (typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        if (typeof event.stopImmediatePropagation === 'function') {
+            event.stopImmediatePropagation();
+        } else if (typeof event.stopPropagation === 'function') {
+            event.stopPropagation();
+        }
+
+        releaseCheckoutOverlay();
+        if (!triggerPaylaterButtonClick()) {
+            renderPaylaterButton();
+        }
+    }
+
     function hideModuleRadio() {
         var moduleRadio = document.getElementById('pmt-paypalac_paylater');
         if (moduleRadio) {
@@ -587,7 +676,6 @@
                 return null;
             }
 
-            hideModuleRadio();
             sdkState.config = config;
             return loadPayPalSdk(config).then(function (paypal) {
                 if (currentRenderRequestId !== renderRequestId) {
@@ -598,8 +686,8 @@
                 var buttonInstance = paypal.Buttons({
                     fundingSource: paypal.FUNDING.PAYLATER,
                     style: {
-                        shape: 'rect',
-                        height: 40,
+                        shape: 'pill',
+                        height: 44,
                         color: 'gold'
                     },
                     // createOrder is called when user clicks the button - this is when we create the PayPal order
@@ -711,13 +799,22 @@
         setPaylaterPayload(event.detail || {});
     });
 
-    // The native radio has no effect on its own -- Pay Later can only be
-    // authorized by clicking the PayPal-rendered button, since selecting the
-    // radio alone does not open the approval popup. Hide the radio (screen
-    // readers can still reach it) so shoppers aren't tempted to click a
-    // control that appears to do nothing; the "PayPal Pay Later" label and
-    // button remain the single visible, actionable control.
-    hideModuleRadio();
+    // Match PayPal: keep the native radio visible and place the branded
+    // Pay Later button to its right (no text label). Confirm Order starts
+    // the same hosted approval that clicking the button does.
+    wrapSubmitCheckout();
+    document.addEventListener('click', wrapSubmitCheckout, true);
+
+    if (!window.__paypalacPaylaterSubmitInterceptInstalled) {
+        window.__paypalacPaylaterSubmitInterceptInstalled = true;
+        document.addEventListener('submit', function (event) {
+            var form = event.target;
+            if (!form || form.getAttribute('name') !== 'checkout_payment') {
+                return;
+            }
+            interceptPaylaterCheckoutSubmit(event);
+        }, true);
+    }
 
     var container = document.getElementById('paypalac-paylater-button');
     if (container) {

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/paypalac.css
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/paypalac.css
@@ -138,7 +138,8 @@
 /* Wallet button containers */
 .paypalac-googlepay-button,
 .paypalac-applepay-button,
-.paypalac-venmo-button {
+.paypalac-venmo-button,
+.paypalac-paylater-button {
     min-height: 40px;
     min-width: var(--paypalac-wallet-button-min-width);
     max-width: var(--paypalac-wallet-button-max-width);
@@ -152,7 +153,8 @@
 
 .paypalac-googlepay-button > *,
 .paypalac-applepay-button > *,
-.paypalac-venmo-button > * {
+.paypalac-venmo-button > *,
+.paypalac-paylater-button > * {
     width: 100%;
     max-width: var(--paypalac-wallet-button-max-width);
     box-sizing: border-box;
@@ -228,7 +230,8 @@ fieldset.payment label.radioButtonLabel[for^="pmt-paypalac_"],
 }
 
 /* OPRC uses payment-method-item-label instead of radioButtonLabel */
-#paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"] {
+#paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"],
+#paymentMethodContainer .custom-radio > label[for^="pmt-paypalac_"] {
     display: inline-flex;
     align-items: center;
     vertical-align: middle;
@@ -240,12 +243,19 @@ fieldset.payment label.radioButtonLabel[for^="pmt-paypalac_"],
 fieldset.payment label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-googlepay-button,
 fieldset.payment label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-applepay-button,
 fieldset.payment label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-venmo-button,
+fieldset.payment label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-paylater-button,
 #paymentMethodContainer label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-googlepay-button,
 #paymentMethodContainer label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-applepay-button,
 #paymentMethodContainer label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-venmo-button,
+#paymentMethodContainer label.radioButtonLabel[for^="pmt-paypalac_"] .paypalac-paylater-button,
 #paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"] .paypalac-googlepay-button,
 #paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"] .paypalac-applepay-button,
-#paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"] .paypalac-venmo-button {
+#paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"] .paypalac-venmo-button,
+#paymentMethodContainer label.payment-method-item-label[for^="pmt-paypalac_"] .paypalac-paylater-button,
+#paymentMethodContainer .custom-radio > label[for^="pmt-paypalac_"] .paypalac-googlepay-button,
+#paymentMethodContainer .custom-radio > label[for^="pmt-paypalac_"] .paypalac-applepay-button,
+#paymentMethodContainer .custom-radio > label[for^="pmt-paypalac_"] .paypalac-venmo-button,
+#paymentMethodContainer .custom-radio > label[for^="pmt-paypalac_"] .paypalac-paylater-button {
     flex: 0 1 auto;
     width: auto;
     min-width: min(320px, 100%);

--- a/includes/modules/payment/paypalac_paylater.php
+++ b/includes/modules/payment/paypalac_paylater.php
@@ -52,7 +52,7 @@ class paypalac_paylater extends base
         return defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.1.0';
+    protected const CURRENT_VERSION = '1.1.1';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -670,11 +670,11 @@ class paypalac_paylater extends base
 
         $script = $this->getWalletAssets('jquery.paypalac.paylater.js');
 
-        $selectionLabel = MODULE_PAYMENT_PAYPALAC_PAYLATER_TEXT_SELECTION ?? 'Pay Later';
-
+        // Match paypalac::selection(): radio + branded button only, no text label.
+        // Confirm Order (or the Pay Later button) starts payment, same as PayPal.
         return [
             'id' => $this->code,
-            'module' => $selectionLabel . ' ' . $buttonContainer . $hiddenFields . $script,
+            'module' => $buttonContainer . $hiddenFields . $script,
         ];
     }
 

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -18,11 +18,11 @@ $langPhp = file_get_contents(__DIR__ . '/../includes/languages/english/modules/p
 fwrite(STDOUT, "Testing Pay Later amount limits\n");
 fwrite(STDOUT, "================================\n\n");
 
-if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.0'") === false) {
-    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.0 so tableCheckup inserts the new amount keys\n");
+if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.1'") === false) {
+    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.1 so tableCheckup still runs after the Pay Later UI/parity update\n");
     $failures++;
 } else {
-    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.0\n");
+    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.1\n");
 }
 
 foreach ([

--- a/tests/PayLaterServerConfirmationAndRadioUiTest.php
+++ b/tests/PayLaterServerConfirmationAndRadioUiTest.php
@@ -1,64 +1,86 @@
 <?php
 /**
- * Test: Pay Later server-side confirmation fix and dead radio-button UI fix.
+ * Test: Pay Later Confirm Order parity with PayPal, plus server confirmation.
  *
  * Background (ticket 615108 / redlinestands.com):
- * - The customer reported that selecting the "PayPal Pay Later" radio button
- *   did nothing -- only clicking the yellow PayPal-rendered button worked,
- *   which was confusing. The native radio was never actually hidden during
- *   normal rendering even though hideModuleRadio()/CSS support already
- *   existed (same latent gap Google Pay/Apple Pay had before their fix).
- * - Separately, the customer still saw "We were unable to confirm your Pay
- *   Later payment with PayPal" even on an eligible cart amount. Pay Later is
- *   approved through PayPal's own hosted popup (paypal.Buttons()), so by the
- *   time onApprove fires the order is already APPROVED; the shared
- *   processWalletConfirmation() was nonetheless calling confirm-payment-source
- *   (a call meant only for orders confirmed without a payment_source, e.g.
- *   card-only multi-step flows), which PayPal was rejecting.
- *
- * This matches the exact class of bug already fixed for Google Pay via
- * client-side confirmation (see GooglePayClientSideConfirmationTest.php);
- * Pay Later instead skips confirm-payment-source server-side and just
- * re-checks the live order status, since no client "confirmed" flag exists
- * for the plain Buttons() flow.
+ * - Pay Later should look and act like the PayPal row: visible native radio,
+ *   branded button to the right, no "PayPal Pay Later" text label. Confirm
+ *   Order (or the button) starts hosted approval, then checkout continues.
+ * - Pay Later is approved through PayPal's hosted popup (paypal.Buttons()),
+ *   so processWalletConfirmation() must skip confirm-payment-source and
+ *   re-check live order status.
  */
 
 $jsFile = __DIR__ . '/../includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js';
 $phpFile = __DIR__ . '/../includes/modules/payment/paypal/paypal_common.php';
+$moduleFile = __DIR__ . '/../includes/modules/payment/paypalac_paylater.php';
 
 $testPassed = true;
 $errors = [];
 
 $jsContent = file_get_contents($jsFile);
 $phpContent = file_get_contents($phpFile);
+$moduleContent = file_get_contents($moduleFile);
 
-// Test 1: hideModuleRadio() is actually invoked during normal rendering,
-// not just defined. (Definition + at least one real call site.)
+// Test 1: hideModuleRadio() is only used when the method is ineligible.
 $hideModuleRadioCallCount = preg_match_all('/\bhideModuleRadio\s*\(\s*\)\s*;/', $jsContent);
-if ($hideModuleRadioCallCount < 2) {
+if ($hideModuleRadioCallCount !== 1) {
     $testPassed = false;
-    $errors[] = "hideModuleRadio() should be invoked outside of hidePaymentMethodContainer() so the dead radio is hidden during normal rendering, not just when the button is unavailable.";
+    $errors[] = "hideModuleRadio() should be invoked once, from hidePaymentMethodContainer(), so the radio stays visible like PayPal during normal rendering (found {$hideModuleRadioCallCount} call sites).";
 } else {
-    echo "✓ Pay Later JS invokes hideModuleRadio() during normal rendering (found {$hideModuleRadioCallCount} call sites)\n";
+    echo "✓ Pay Later JS keeps the radio visible during normal rendering (hideModuleRadio only when ineligible)\n";
+}
+
+if (!preg_match('/function hidePaymentMethodContainer\s*\([^)]*\)\s*\{[\s\S]*?\bhideModuleRadio\s*\(\s*\)\s*;/', $jsContent)) {
+    $testPassed = false;
+    $errors[] = "hideModuleRadio() must still run from hidePaymentMethodContainer() when Pay Later is unavailable.";
+} else {
+    echo "✓ hideModuleRadio() still hides the radio when Pay Later is ineligible\n";
 }
 
 if (strpos($jsContent, 'paypalac-wallet-radio-hidden-control') === false) {
     $testPassed = false;
-    $errors[] = "hideModuleRadio() must mark the theme custom-radio wrapper so label::before (the visible circle) is hidden, not just the already-invisible input.";
+    $errors[] = "hideModuleRadio() must mark the theme custom-radio wrapper so label::before is hidden when the method is ineligible.";
 } else {
-    echo "✓ Pay Later JS marks the custom-radio wrapper so the visible fake radio is hidden\n";
+    echo "✓ Pay Later JS marks the custom-radio wrapper when hiding an ineligible method\n";
 }
 
-// Test 2: The label text is NOT hidden by default (only the radio), so the
-// shopper still sees "PayPal Pay Later" for context next to the button.
+// Test 2: Confirm Order intercept matches the PayPal checkout process.
+if (strpos($jsContent, 'function wrapSubmitCheckout') === false
+    || strpos($jsContent, 'function triggerPaylaterButtonClick') === false
+    || strpos($jsContent, 'function interceptPaylaterCheckoutSubmit') === false
+) {
+    $testPassed = false;
+    $errors[] = "Pay Later JS should intercept Confirm Order / submitCheckout and start the Pay Later button, matching the PayPal Confirm Order process.";
+} else {
+    echo "✓ Pay Later JS intercepts Confirm Order and starts Pay Later approval\n";
+}
+
+if (strpos($jsContent, "shape: 'pill'") === false) {
+    $testPassed = false;
+    $errors[] = "Pay Later button should use pill shape to match the PayPal branded button.";
+} else {
+    echo "✓ Pay Later button uses pill shape\n";
+}
+
 if (strpos($jsContent, 'Keep the mock radio button visible') !== false) {
     $testPassed = false;
     $errors[] = "Stale comment claiming the radio is intentionally kept visible should be removed/updated.";
 } else {
-    echo "✓ Stale 'keep radio visible' comment has been updated\n";
+    echo "✓ Stale 'keep radio visible' comment is not present\n";
 }
 
-// Test 3: paypal_common.php has a dedicated 'paylater' branch in
+// Test 3: selection() is radio + button only (no text label), like paypalac.
+if (preg_match('/\$selectionLabel\s*\.\s*[\'"]\s*[\'"]?\s*\.\s*\$buttonContainer/', $moduleContent)
+    || preg_match("/'module'\s*=>\s*\$selectionLabel/", $moduleContent)
+) {
+    $testPassed = false;
+    $errors[] = "selection() should render only the Pay Later button (no text label), matching paypalac::selection().";
+} else {
+    echo "✓ Pay Later selection() does not prepend label text next to the button\n";
+}
+
+// Test 4: paypal_common.php has a dedicated 'paylater' branch in
 // processWalletConfirmation().
 if (!preg_match('/if\s*\(\$walletType\s*===\s*[\'"]paylater[\'"]\)\s*\{/', $phpContent, $matches, PREG_OFFSET_CAPTURE)) {
     $testPassed = false;
@@ -66,15 +88,11 @@ if (!preg_match('/if\s*\(\$walletType\s*===\s*[\'"]paylater[\'"]\)\s*\{/', $phpC
 } else {
     $branchStart = $matches[0][1];
 
-    // Isolate roughly the paylater branch body up to its "return;" so we can
-    // check it doesn't call confirmPaymentSource but does call getOrderStatus.
     $branchEnd = strpos($phpContent, 'return;', $branchStart);
     $branchBody = $branchEnd !== false
         ? substr($phpContent, $branchStart, $branchEnd - $branchStart)
         : substr($phpContent, $branchStart, 2000);
 
-    // Test 4: Pay Later branch must NOT call confirmPaymentSource (look for
-    // the actual method call, not just the word appearing in a log message).
     if (strpos($branchBody, '->confirmPaymentSource(') !== false) {
         $testPassed = false;
         $errors[] = "The paylater branch should not call confirmPaymentSource(); Pay Later orders are already approved via the hosted popup by the time onApprove fires.";
@@ -82,7 +100,6 @@ if (!preg_match('/if\s*\(\$walletType\s*===\s*[\'"]paylater[\'"]\)\s*\{/', $phpC
         echo "✓ Pay Later branch does not call confirmPaymentSource()\n";
     }
 
-    // Test 5: Pay Later branch must call getOrderStatus to re-verify the order.
     if (strpos($branchBody, 'getOrderStatus') === false) {
         $testPassed = false;
         $errors[] = "The paylater branch should call getOrderStatus() to verify the order before proceeding.";
@@ -90,8 +107,6 @@ if (!preg_match('/if\s*\(\$walletType\s*===\s*[\'"]paylater[\'"]\)\s*\{/', $phpC
         echo "✓ Pay Later branch calls getOrderStatus() to verify the order\n";
     }
 
-    // Test 6: Pay Later branch must still surface confirm_failed on a hard
-    // failure, and mark wallet_payment_confirmed on success.
     if (strpos($branchBody, "errorMessages['confirm_failed']") === false) {
         $testPassed = false;
         $errors[] = "The paylater branch should still redirect with confirm_failed if getOrderStatus() fails outright.";
@@ -107,8 +122,6 @@ if (!preg_match('/if\s*\(\$walletType\s*===\s*[\'"]paylater[\'"]\)\s*\{/', $phpC
     }
 }
 
-// Test 7: The new paylater branch must run before the generic
-// confirmPaymentSource fallthrough (order matters -- PHP returns early).
 $paylaterBranchPos = strpos($phpContent, "if (\$walletType === 'paylater')");
 $genericConfirmPos = strpos($phpContent, '$confirm_response = $this->paymentModule->ppr->confirmPaymentSource(');
 if ($paylaterBranchPos === false || $genericConfirmPos === false || $paylaterBranchPos >= $genericConfirmPos) {


### PR DESCRIPTION
## Summary
- Pay Later now matches the PayPal row: visible radio, branded button to the right, no `PayPal Pay Later` text label.
- Confirm Order (OPRC `submitCheckout` or native `checkout_payment` submit) starts Pay Later hosted approval the same way clicking the yellow button does, then checkout continues after approval.
- The radio is only hidden when Pay Later is ineligible (amount limits / SDK).

## Test plan
- [x] Plugin tests: PayLaterAmountLimits, PayLaterServerConfirmationAndRadioUi, WalletModuleRadioHidden
- [ ] On checkout $30–: radio + Pay Later pill, no text label
- [ ] Select Pay Later and click Confirm Order: Pay Later popup/approval, then order continues
- [ ] Clicking the yellow Pay Later button still works
- [ ] Cart over $2000: Pay Later row stays hidden