### PR TITLE
NX-615108: Fix Pay Later Confirm Order via approval redirect

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php
@@ -213,12 +213,18 @@ class CreatePayPalOrderRequest extends ErrorInfo
             }
         } elseif ($ppac_type === 'google_pay') {
             $this->request['payment_source']['google_pay'] = new \stdClass();
+        } elseif ($ppac_type === 'paylater' && !empty($_SESSION['PayPalAdvancedCheckout']['PayLaterRedirectApproval'])) {
+            // Confirm Order path: create with payment_source.paylater + experience_context
+            // so PayPal returns a payer-action / approve URL. The Buttons() popup path
+            // omits payment_source and lets the JS SDK attach Pay Later instead.
+            $this->request['payment_source']['paylater'] = $this->buildPayLaterPaymentSource($order);
         }
 
         $payment_source_types = isset($this->request['payment_source']) ? implode(', ', array_keys($this->request['payment_source'])) : 'none';
         $this->log->write("Payment source type: {$payment_source_types}");
 
         // For venmo - do NOT include payment_source; the PayPal SDK handles the payment source during the wallet authorization flow
+        // For paylater Buttons() popup - same (omit payment_source unless PayLaterRedirectApproval is set)
 
         $this->log->write("\nCreatePayPalOrderRequest::__construct($ppac_type, ...) finished, request:\n" . Logger::logJSON($this->request, true, true));
     }
@@ -1023,6 +1029,33 @@ class CreatePayPalOrderRequest extends ErrorInfo
         }
 
         return $payment_source;
+    }
+
+    /**
+     * Pay Later redirect (Confirm Order) payment source with return/cancel URLs.
+     */
+    protected function buildPayLaterPaymentSource(\order $order): array
+    {
+        $shipping_preference = ($order->content_type === 'virtual') ? 'NO_SHIPPING' : 'SET_PROVIDED_ADDRESS';
+        $brand_name = (defined('MODULE_PAYMENT_PAYPALAC_BRANDNAME') && MODULE_PAYMENT_PAYPALAC_BRANDNAME !== '')
+            ? MODULE_PAYMENT_PAYPALAC_BRANDNAME
+            : STORE_NAME;
+        $listener_endpoint = $this->resolveListenerEndpoint(null);
+
+        return [
+            'name' => [
+                'given_name' => $order->billing['firstname'],
+                'surname' => $order->billing['lastname'],
+            ],
+            'email_address' => $order->customer['email_address'],
+            'experience_context' => [
+                'brand_name' => $brand_name,
+                'shipping_preference' => $shipping_preference,
+                'user_action' => 'PAY_NOW',
+                'return_url' => $listener_endpoint . '?op=return',
+                'cancel_url' => $listener_endpoint . '?op=cancel',
+            ],
+        ];
     }
 
     protected function resolveListenerEndpoint(?string $listener_endpoint): string

--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
@@ -283,20 +283,44 @@
             || container.querySelector('iframe');
     }
 
-    function triggerPaylaterButtonClick() {
+    function fetchPayLaterConfirmRedirect() {
+        return fetch('ppac_wallet.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ wallet: 'paylater', confirm_redirect: true })
+        }).then(parseWalletResponse).catch(function (error) {
+            console.error('Unable to start Pay Later Confirm Order redirect', error);
+            return {
+                success: false,
+                message: error && error.message ? error.message : 'Unable to start Pay Later'
+            };
+        });
+    }
+
+    function startPayLaterConfirmOrderRedirect() {
         selectPaylaterRadio();
-        var button = getPaylaterButtonElement();
-        if (!button) {
-            return false;
+        releaseCheckoutOverlay();
+
+        if (typeof window.oprcShowProcessingOverlay === 'function') {
+            window.oprcShowProcessingOverlay();
+        } else if (typeof jQuery !== 'undefined' && typeof jQuery.blockUI === 'function') {
+            jQuery.blockUI();
         }
 
-        try {
-            button.click();
-            return true;
-        } catch (error) {
-            console.warn('Unable to start Pay Later from Confirm Order', error);
+        return fetchPayLaterConfirmRedirect().then(function (result) {
+            if (result && result.success && result.approveUrl) {
+                window.location.href = result.approveUrl;
+                return true;
+            }
+
+            console.error('Pay Later Confirm Order redirect failed', result);
+            releaseCheckoutOverlay();
+            var message = (result && result.message)
+                ? result.message
+                : 'Unable to start Pay Later. Please click the Pay Later button, or try again.';
+            window.alert(message);
             return false;
-        }
+        });
     }
 
     function wrapSubmitCheckout() {
@@ -307,10 +331,7 @@
         var originalSubmitCheckout = window.submitCheckout;
         function wrappedSubmitCheckout() {
             if (shouldStartPayLaterApproval()) {
-                releaseCheckoutOverlay();
-                if (!triggerPaylaterButtonClick()) {
-                    renderPaylaterButton();
-                }
+                startPayLaterConfirmOrderRedirect();
                 return false;
             }
 
@@ -340,10 +361,31 @@
             event.stopPropagation();
         }
 
-        releaseCheckoutOverlay();
-        if (!triggerPaylaterButtonClick()) {
-            renderPaylaterButton();
+        startPayLaterConfirmOrderRedirect();
+    }
+
+    function interceptConfirmOrderClick(event) {
+        wrapSubmitCheckout();
+
+        var submitRoot = document.getElementById('js-submit');
+        if (!submitRoot || !event.target || !submitRoot.contains(event.target)) {
+            return;
         }
+
+        if (!shouldStartPayLaterApproval()) {
+            return;
+        }
+
+        if (typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        if (typeof event.stopImmediatePropagation === 'function') {
+            event.stopImmediatePropagation();
+        } else if (typeof event.stopPropagation === 'function') {
+            event.stopPropagation();
+        }
+
+        startPayLaterConfirmOrderRedirect();
     }
 
     function hideModuleRadio() {
@@ -801,9 +843,10 @@
 
     // Match PayPal: keep the native radio visible and place the branded
     // Pay Later button to its right (no text label). Confirm Order starts
-    // the same hosted approval that clicking the button does.
+    // a full-page Pay Later approval redirect (browsers block synthetic
+    // clicks on the hosted Buttons iframe).
     wrapSubmitCheckout();
-    document.addEventListener('click', wrapSubmitCheckout, true);
+    document.addEventListener('click', interceptConfirmOrderClick, true);
 
     if (!window.__paypalacPaylaterSubmitInterceptInstalled) {
         window.__paypalacPaylaterSubmitInterceptInstalled = true;

--- a/includes/modules/payment/paypal/paypal_common.php
+++ b/includes/modules/payment/paypal/paypal_common.php
@@ -1757,6 +1757,17 @@ class PayPalCommon {
             "  Status: $status"
         );
 
+        $approve_url = '';
+        foreach ($paypal_order['links'] ?? [] as $next_link) {
+            $rel = $next_link['rel'] ?? '';
+            if (in_array($rel, ['payer-action', 'approve'], true) && !empty($next_link['href'])) {
+                $approve_url = (string)$next_link['href'];
+                if ($rel === 'payer-action') {
+                    break;
+                }
+            }
+        }
+
         unset(
             $paypal_order['id'],
             $paypal_order['status'],
@@ -1774,6 +1785,10 @@ class PayPalCommon {
             'payment_source' => $ppac_type,
             'amount_mismatch' => $order_amount_mismatch,
         ];
+
+        if ($approve_url !== '' && !empty($_SESSION['PayPalAdvancedCheckout']['PayLaterRedirectApproval'])) {
+            $_SESSION['PayPalAdvancedCheckout']['Order']['approve_url'] = $approve_url;
+        }
 
         // Card checkout: PayPal may capture/authorize during createOrder (vault / fast path). Claim the
         // payment resource id immediately so a concurrent finalize cannot insert a second Zen order

--- a/includes/modules/payment/paypalac_paylater.php
+++ b/includes/modules/payment/paypalac_paylater.php
@@ -52,7 +52,7 @@ class paypalac_paylater extends base
         return defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.1.1';
+    protected const CURRENT_VERSION = '1.1.2';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -756,8 +756,103 @@ class paypalac_paylater extends base
         return $response;
     }
 
+    /**
+     * Confirm Order path: create a Pay Later order with experience_context and
+     * return the PayPal approve / payer-action URL for a full-page redirect.
+     * Synthetic clicks on the hosted Buttons iframe are blocked by browsers.
+     */
+    public function ajaxCreatePayLaterConfirmRedirect(): array
+    {
+        $limit_context = $this->getPayLaterLimitContext();
+        if ($limit_context['withinLimits'] === false) {
+            return $this->buildPayLaterAmountLimitFailure($this->getPayLaterLimitFailureReason($limit_context));
+        }
+
+        // Force a fresh PayPal order with payment_source.paylater (do not reuse a
+        // Buttons()-style CREATED order that omitted payment_source).
+        unset($_SESSION['PayPalAdvancedCheckout']['Order']);
+        $_SESSION['PayPalAdvancedCheckout']['PayLaterRedirectApproval'] = true;
+        $_SESSION['PayPalAdvancedCheckout']['ppac_type'] = 'paylater';
+
+        try {
+            if ($this->createPayPalOrder('paylater', false) === false) {
+                return [
+                    'success' => false,
+                    'message' => MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE ?? 'Unable to start Pay Later. Please try again.',
+                    'reason' => 'order_creation_failed',
+                ] + $limit_context;
+            }
+        } finally {
+            unset($_SESSION['PayPalAdvancedCheckout']['PayLaterRedirectApproval']);
+        }
+
+        $orderData = $_SESSION['PayPalAdvancedCheckout']['Order'] ?? [];
+        $approveUrl = trim((string)($orderData['approve_url'] ?? ''));
+        $orderId = trim((string)($orderData['id'] ?? ''));
+
+        if ($approveUrl === '' || $orderId === '') {
+            $this->log->write('Pay Later Confirm Order redirect missing approve URL or order id after create.', true, 'after');
+            return [
+                'success' => false,
+                'message' => MODULE_PAYMENT_PAYPALAC_PAYLATER_ERROR_INITIALIZE ?? 'Unable to start Pay Later. Please try again.',
+                'reason' => 'approve_url_missing',
+            ] + $limit_context;
+        }
+
+        $this->storePayLaterPayerAction($approveUrl);
+
+        return [
+            'success' => true,
+            'orderID' => $orderId,
+            'approveUrl' => $approveUrl,
+        ] + $limit_context;
+    }
+
+    protected function storePayLaterPayerAction(string $approveUrl): void
+    {
+        global $current_page_base;
+
+        $savedPosts = $_POST;
+        unset($savedPosts['request']);
+        if (!isset($savedPosts['payment'])) {
+            $savedPosts['payment'] = $this->code;
+        }
+        if (!isset($savedPosts['ppac_type'])) {
+            $savedPosts['ppac_type'] = 'paylater';
+        }
+
+        $redirectPage = 'one_page_checkout';
+        if (defined('FILENAME_ONE_PAGE_CHECKOUT')) {
+            $redirectPage = FILENAME_ONE_PAGE_CHECKOUT;
+        } elseif (defined('FILENAME_CHECKOUT_CONFIRMATION')) {
+            $redirectPage = FILENAME_CHECKOUT_CONFIRMATION;
+        }
+
+        if (!isset($_SESSION['PayPalAdvancedCheckout']['Order']) || !is_array($_SESSION['PayPalAdvancedCheckout']['Order'])) {
+            $_SESSION['PayPalAdvancedCheckout']['Order'] = [];
+        }
+
+        $_SESSION['PayPalAdvancedCheckout']['Order']['PayerAction'] = [
+            'current_page_base' => $current_page_base ?? $redirectPage,
+            'redirect_page' => $redirectPage,
+            'savedPosts' => $savedPosts,
+            'payer_action_link' => $approveUrl,
+        ];
+        $_SESSION['PayPalAdvancedCheckout']['Order']['payment_source'] = 'paylater';
+    }
+
     public function pre_confirmation_check()
     {
+        // Returning from PayPal after Confirm Order redirect: payload may be empty
+        // but wallet_payment_confirmed was set by ppac_listener.
+        if (!empty($_SESSION['PayPalAdvancedCheckout']['Order']['wallet_payment_confirmed'])
+            && (($_SESSION['PayPalAdvancedCheckout']['Order']['payment_source'] ?? '') === 'paylater'
+                || ($_SESSION['PayPalAdvancedCheckout']['ppac_type'] ?? '') === 'paylater')
+        ) {
+            $this->log->write('pre_confirmation_check (paylater): wallet already confirmed via redirect return.', true, 'after');
+            return;
+        }
+
         $this->paypalCommon->processWalletConfirmation(
             'paylater',
             'paypalac_paylater_payload',

--- a/ppac_wallet.php
+++ b/ppac_wallet.php
@@ -19,6 +19,7 @@ $requestData = json_decode($requestBody, true) ?: [];
 
 $wallet = $requestData['wallet'] ?? '';
 $configOnly = !empty($requestData['config_only']);
+$confirmRedirect = !empty($requestData['confirm_redirect']);
 $payloadData = $requestData['payload'] ?? null;
 
 // -----
@@ -188,6 +189,13 @@ if ($configOnly) {
     // whether the viewed product is virtual (not based on the cart).
     $productsId = isset($requestData['products_id']) ? (int)$requestData['products_id'] : 0;
     $response = $moduleInstance->ajaxGetWalletConfig($productsId);
+} elseif ($confirmRedirect && $wallet === 'paylater') {
+    if (!method_exists($moduleInstance, 'ajaxCreatePayLaterConfirmRedirect')) {
+        echo json_encode(['success' => false, 'message' => 'Wallet module missing Confirm Order redirect handler']);
+        require DIR_WS_INCLUDES . 'application_bottom.php';
+        return;
+    }
+    $response = $moduleInstance->ajaxCreatePayLaterConfirmRedirect();
 } else {
     if (!method_exists($moduleInstance, 'ajaxCreateWalletOrder')) {
         echo json_encode(['success' => false, 'message' => 'Wallet module missing AJAX handler']);

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -18,11 +18,11 @@ $langPhp = file_get_contents(__DIR__ . '/../includes/languages/english/modules/p
 fwrite(STDOUT, "Testing Pay Later amount limits\n");
 fwrite(STDOUT, "================================\n\n");
 
-if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.1'") === false) {
-    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.1 so tableCheckup still runs after the Pay Later UI/parity update\n");
+if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.2'") === false) {
+    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.2 after the Confirm Order redirect fix\n");
     $failures++;
 } else {
-    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.1\n");
+    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.2\n");
 }
 
 foreach ([

--- a/tests/PayLaterServerConfirmationAndRadioUiTest.php
+++ b/tests/PayLaterServerConfirmationAndRadioUiTest.php
@@ -45,15 +45,16 @@ if (strpos($jsContent, 'paypalac-wallet-radio-hidden-control') === false) {
     echo "✓ Pay Later JS marks the custom-radio wrapper when hiding an ineligible method\n";
 }
 
-// Test 2: Confirm Order intercept matches the PayPal checkout process.
+// Test 2: Confirm Order intercept matches the PayPal checkout process via redirect.
 if (strpos($jsContent, 'function wrapSubmitCheckout') === false
-    || strpos($jsContent, 'function triggerPaylaterButtonClick') === false
+    || strpos($jsContent, 'function startPayLaterConfirmOrderRedirect') === false
     || strpos($jsContent, 'function interceptPaylaterCheckoutSubmit') === false
+    || strpos($jsContent, 'confirm_redirect') === false
 ) {
     $testPassed = false;
-    $errors[] = "Pay Later JS should intercept Confirm Order / submitCheckout and start the Pay Later button, matching the PayPal Confirm Order process.";
+    $errors[] = "Pay Later JS should intercept Confirm Order and redirect to PayPal Pay Later approval (confirm_redirect), matching the PayPal Confirm Order process.";
 } else {
-    echo "✓ Pay Later JS intercepts Confirm Order and starts Pay Later approval\n";
+    echo "✓ Pay Later JS intercepts Confirm Order and starts a Pay Later approval redirect\n";
 }
 
 if (strpos($jsContent, "shape: 'pill'") === false) {


### PR DESCRIPTION
## Summary
- Confirm Order with Pay Later selected did nothing because browsers block synthetic clicks on the hosted PayPal Buttons iframe.
- Confirm Order now creates a Pay Later order with `experience_context` and redirects to PayPal's approve / payer-action URL (same end result as the yellow button, via full-page approval).
- Yellow Pay Later button popup path is unchanged.

## Test plan
- [x] Plugin tests: PayLaterAmountLimits, PayLaterServerConfirmationAndRadioUi
- [ ] Select Pay Later radio + CONFIRM ORDER on OPRC: redirects to PayPal Pay Later approval
- [ ] Click yellow Pay Later button: popup still works
- [ ] After approval return, checkout can complete