### PR TITLE
Fix Pay Later Confirm Order: use payment_source.paypal

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php
@@ -214,10 +214,12 @@ class CreatePayPalOrderRequest extends ErrorInfo
         } elseif ($ppac_type === 'google_pay') {
             $this->request['payment_source']['google_pay'] = new \stdClass();
         } elseif ($ppac_type === 'paylater' && !empty($_SESSION['PayPalAdvancedCheckout']['PayLaterRedirectApproval'])) {
-            // Confirm Order path: create with payment_source.paylater + experience_context
-            // so PayPal returns a payer-action / approve URL. The Buttons() popup path
-            // omits payment_source and lets the JS SDK attach Pay Later instead.
-            $this->request['payment_source']['paylater'] = $this->buildPayLaterPaymentSource($order);
+            // Confirm Order path: Orders v2 does not accept payment_source.paylater
+            // (returns NO_PAYMENT_SOURCE_PROVIDED). Use payment_source.paypal with
+            // experience_context so PayPal returns a payer-action / approve URL; the
+            // approve URL is then opened with fundingSource=paylater. The Buttons()
+            // popup path omits payment_source and lets the JS SDK attach Pay Later.
+            $this->request['payment_source']['paypal'] = $this->buildPayLaterRedirectPaymentSource($order);
         }
 
         $payment_source_types = isset($this->request['payment_source']) ? implode(', ', array_keys($this->request['payment_source'])) : 'none';
@@ -1032,9 +1034,10 @@ class CreatePayPalOrderRequest extends ErrorInfo
     }
 
     /**
-     * Pay Later redirect (Confirm Order) payment source with return/cancel URLs.
+     * Pay Later Confirm Order redirect: Orders v2 payment_source.paypal shape
+     * (paylater is not a valid create-order payment_source key) plus return/cancel URLs.
      */
-    protected function buildPayLaterPaymentSource(\order $order): array
+    protected function buildPayLaterRedirectPaymentSource(\order $order): array
     {
         $shipping_preference = ($order->content_type === 'virtual') ? 'NO_SHIPPING' : 'SET_PROVIDED_ADDRESS';
         $brand_name = (defined('MODULE_PAYMENT_PAYPALAC_BRANDNAME') && MODULE_PAYMENT_PAYPALAC_BRANDNAME !== '')

--- a/includes/modules/payment/paypal/paypal_common.php
+++ b/includes/modules/payment/paypal/paypal_common.php
@@ -1787,6 +1787,11 @@ class PayPalCommon {
         ];
 
         if ($approve_url !== '' && !empty($_SESSION['PayPalAdvancedCheckout']['PayLaterRedirectApproval'])) {
+            // Prefer the Pay Later funding UI on the hosted checkout page (Orders
+            // create uses payment_source.paypal; fundingSource selects Pay Later).
+            if (stripos($approve_url, 'fundingSource=') === false) {
+                $approve_url .= (strpos($approve_url, '?') === false ? '?' : '&') . 'fundingSource=paylater';
+            }
             $_SESSION['PayPalAdvancedCheckout']['Order']['approve_url'] = $approve_url;
         }
 

--- a/includes/modules/payment/paypalac_paylater.php
+++ b/includes/modules/payment/paypalac_paylater.php
@@ -52,7 +52,7 @@ class paypalac_paylater extends base
         return defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.1.3';
+    protected const CURRENT_VERSION = '1.1.4';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,
@@ -757,8 +757,9 @@ class paypalac_paylater extends base
     }
 
     /**
-     * Confirm Order path: create a Pay Later order with experience_context and
-     * return the PayPal approve / payer-action URL for a full-page redirect.
+     * Confirm Order path: create an order with payment_source.paypal +
+     * experience_context (Orders v2 rejects payment_source.paylater) and return
+     * the approve / payer-action URL (with fundingSource=paylater) for redirect.
      * Synthetic clicks on the hosted Buttons iframe are blocked by browsers.
      */
     public function ajaxCreatePayLaterConfirmRedirect(): array

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -18,11 +18,11 @@ $langPhp = file_get_contents(__DIR__ . '/../includes/languages/english/modules/p
 fwrite(STDOUT, "Testing Pay Later amount limits\n");
 fwrite(STDOUT, "================================\n\n");
 
-if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.3'") === false) {
-    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.3 after the Confirm Order intercept fix\n");
+if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.4'") === false) {
+    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.4 after the Confirm Order payment_source.paypal fix\n");
     $failures++;
 } else {
-    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.3\n");
+    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.4\n");
 }
 
 foreach ([

--- a/tests/PayLaterServerConfirmationAndRadioUiTest.php
+++ b/tests/PayLaterServerConfirmationAndRadioUiTest.php
@@ -132,6 +132,26 @@ if ($paylaterBranchPos === false || $genericConfirmPos === false || $paylaterBra
     echo "✓ Pay Later branch is checked before the generic confirmPaymentSource fallthrough\n";
 }
 
+// Test 5: Confirm Order create uses payment_source.paypal (Orders v2 rejects paylater).
+$createRequestFile = __DIR__ . '/../includes/modules/payment/paypal/PayPalAdvancedCheckout/Zc2Pp/CreatePayPalOrderRequest.php';
+$createRequestContent = file_get_contents($createRequestFile);
+if ($createRequestContent === false
+    || strpos($createRequestContent, "['payment_source']['paypal'] = \$this->buildPayLaterRedirectPaymentSource") === false
+    || strpos($createRequestContent, "['payment_source']['paylater']") !== false
+) {
+    $testPassed = false;
+    $errors[] = "Confirm Order create must use payment_source.paypal via buildPayLaterRedirectPaymentSource (not payment_source.paylater).";
+} else {
+    echo "✓ Confirm Order create uses payment_source.paypal (Orders v2 compatible)\n";
+}
+
+if (strpos($phpContent, 'fundingSource=paylater') === false) {
+    $testPassed = false;
+    $errors[] = "Approve URL for Pay Later Confirm Order redirect should append fundingSource=paylater.";
+} else {
+    echo "✓ Pay Later Confirm Order approve URL appends fundingSource=paylater\n";
+}
+
 echo "\n";
 if ($testPassed) {
     echo "All tests passed! ✓\n";


### PR DESCRIPTION
﻿## Summary
- Orders v2 rejects payment_source.paylater with NO_PAYMENT_SOURCE_PROVIDED, which made Confirm Order alert that Pay Later is unavailable while the yellow Buttons path still worked.
- Create Confirm Order redirect orders with payment_source.paypal + experience_context, then append fundingSource=paylater to the approve URL.
- Bump Pay Later module to 1.1.4 and extend regression tests.

## Test plan
- [ ] On checkout with Pay Later selected, Confirm Order redirects to PayPal Pay Later (no unavailable alert)
- [ ] Yellow Pay Later button still opens the hosted modal
- [ ] After approval return, order can complete
- [ ] php tests/PayLaterAmountLimitsTest.php and php tests/PayLaterServerConfirmationAndRadioUiTest.php pass
