### PR TITLE
Keep Pay Later after cancel; fix Confirm Order overlay

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
@@ -181,10 +181,7 @@
         }
 
         checkoutSubmitting = true;
-
-        if (typeof window.oprcShowProcessingOverlay === 'function') {
-            window.oprcShowProcessingOverlay();
-        }
+        showCheckoutProcessingOverlay();
 
         var previousAllowState = typeof window.oprcAllowNativeCheckoutSubmit !== 'undefined'
             ? window.oprcAllowNativeCheckoutSubmit
@@ -326,16 +323,56 @@
         });
     }
 
+    function showCheckoutProcessingOverlay() {
+        // Prefer OPRC's overlay helper when present (newer plugin builds).
+        if (typeof window.oprcShowProcessingOverlay === 'function') {
+            window.oprcShowProcessingOverlay();
+            return;
+        }
+
+        // Redline / older OPRC themes expose blockPage() with the branded message.
+        if (typeof window.blockPage === 'function') {
+            window.blockPage(false, false);
+            return;
+        }
+
+        if (typeof jQuery === 'undefined' || typeof jQuery.blockUI !== 'function') {
+            return;
+        }
+
+        var message = (typeof oprcProcessingText !== 'undefined' && oprcProcessingText)
+            ? oprcProcessingText
+            : 'Please wait…';
+        var blockOptions = { message: message };
+
+        if (typeof oprcMessageBackground !== 'undefined') {
+            blockOptions.css = {
+                border: 'none',
+                padding: '15px',
+                backgroundColor: oprcMessageBackground,
+                '-webkit-border-radius': '10px',
+                '-moz-border-radius': '10px',
+                opacity: (typeof oprcMessageOpacity !== 'undefined') ? oprcMessageOpacity : 0.8,
+                color: (typeof oprcMessageTextColor !== 'undefined') ? oprcMessageTextColor : '#fff'
+            };
+        }
+
+        if (typeof oprcMessageOverlayColor !== 'undefined') {
+            blockOptions.overlayCSS = {
+                backgroundColor: oprcMessageOverlayColor,
+                color: (typeof oprcMessageOverlayTextColor !== 'undefined') ? oprcMessageOverlayTextColor : '#000',
+                opacity: (typeof oprcMessageOverlayOpacity !== 'undefined') ? oprcMessageOverlayOpacity : 0.6
+            };
+        }
+
+        jQuery.blockUI(blockOptions);
+    }
+
     function startPayLaterConfirmOrderRedirect() {
         selectPaylaterRadio();
         clearPaylaterApprovedStatus();
         releaseCheckoutOverlay();
-
-        if (typeof window.oprcShowProcessingOverlay === 'function') {
-            window.oprcShowProcessingOverlay();
-        } else if (typeof jQuery !== 'undefined' && typeof jQuery.blockUI === 'function') {
-            jQuery.blockUI();
-        }
+        showCheckoutProcessingOverlay();
 
         return fetchPayLaterConfirmRedirect().then(function (result) {
             if (result && result.success && result.approveUrl) {
@@ -372,6 +409,9 @@
     }
 
     function releaseCheckoutOverlay() {
+        if (typeof window.oprcHideProcessingOverlay === 'function') {
+            window.oprcHideProcessingOverlay();
+        }
         if (typeof jQuery !== 'undefined' && typeof jQuery.unblockUI === 'function') {
             jQuery.unblockUI();
         }
@@ -506,9 +546,8 @@
     }
 
     /**
-     * Hide the entire payment method container when payment is not eligible.
-     * This hides the parent element (e.g., paypalac_paylater-custom-control-container)
-     * so the user doesn't see an unavailable payment option.
+     * Hide the entire payment method when it cannot be used at all (config
+     * failure or amount outside Pay Later limits).
      */
     function hidePaymentMethodContainer() {
         hideModuleRadio();
@@ -522,6 +561,19 @@
 
         var container = document.getElementById('paypalac-paylater-button');
         if (container) {
+            container.style.display = 'none';
+        }
+    }
+
+    /**
+     * Buttons SDK can report Pay Later ineligible after a cancel/return even
+     * though Confirm Order redirect still works. Keep the radio row visible and
+     * only clear the yellow button so shoppers can still use Confirm Order.
+     */
+    function hidePayLaterButtonOnly() {
+        var container = document.getElementById('paypalac-paylater-button');
+        if (container) {
+            container.innerHTML = '';
             container.style.display = 'none';
         }
     }
@@ -790,6 +842,7 @@
             }
 
             sdkState.config = config;
+            container.style.display = '';
             return loadPayPalSdk(config).then(function (paypal) {
                 if (currentRenderRequestId !== renderRequestId) {
                     return null;
@@ -846,16 +899,18 @@
                     }
                 });
 
-                // Check if Pay Later is eligible for this user/device
+                // Buttons eligibility is for the yellow widget only. Confirm Order
+                // uses a server redirect and must remain available when the SDK
+                // reports ineligible (common after cancel/return from PayPal).
                 try {
                     if (typeof buttonInstance.isEligible === 'function' && !buttonInstance.isEligible()) {
-                        console.log('Pay Later is not eligible for this user/device');
-                        hidePaymentMethodContainer();
+                        console.log('Pay Later Buttons widget is not eligible; keeping radio for Confirm Order');
+                        hidePayLaterButtonOnly();
                         return null;
                     }
                 } catch (eligibilityError) {
-                    console.warn('Error checking Pay Later eligibility:', eligibilityError);
-                    hidePaymentMethodContainer();
+                    console.warn('Error checking Pay Later Buttons eligibility:', eligibilityError);
+                    hidePayLaterButtonOnly();
                     return null;
                 }
 
@@ -871,7 +926,7 @@
             }
 
             console.error('Failed to render Pay Later button', error);
-            hidePaymentMethodContainer();
+            hidePayLaterButtonOnly();
         });
     }
 

--- a/includes/modules/payment/paypalac_paylater.php
+++ b/includes/modules/payment/paypalac_paylater.php
@@ -52,7 +52,7 @@ class paypalac_paylater extends base
         return defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.1.4';
+    protected const CURRENT_VERSION = '1.1.5';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -18,11 +18,11 @@ $langPhp = file_get_contents(__DIR__ . '/../includes/languages/english/modules/p
 fwrite(STDOUT, "Testing Pay Later amount limits\n");
 fwrite(STDOUT, "================================\n\n");
 
-if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.4'") === false) {
-    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.4 after the Confirm Order payment_source.paypal fix\n");
+if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.5'") === false) {
+    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.5 after cancel-hide/overlay fix\n");
     $failures++;
 } else {
-    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.4\n");
+    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.5\n");
 }
 
 foreach ([

--- a/tests/PayLaterServerConfirmationAndRadioUiTest.php
+++ b/tests/PayLaterServerConfirmationAndRadioUiTest.php
@@ -152,6 +152,26 @@ if (strpos($phpContent, 'fundingSource=paylater') === false) {
     echo "✓ Pay Later Confirm Order approve URL appends fundingSource=paylater\n";
 }
 
+// Test 6: Buttons ineligibility must not hide Confirm Order radio; overlay uses OPRC/mower message.
+if (strpos($jsContent, 'function hidePayLaterButtonOnly') === false
+    || strpos($jsContent, 'keeping radio for Confirm Order') === false
+) {
+    $testPassed = false;
+    $errors[] = "Pay Later JS should hide only the Buttons widget when ineligible so Confirm Order remains available.";
+} else {
+    echo "✓ Buttons ineligibility keeps the Pay Later radio for Confirm Order\n";
+}
+
+if (strpos($jsContent, 'function showCheckoutProcessingOverlay') === false
+    || strpos($jsContent, 'blockPage') === false
+    || strpos($jsContent, 'oprcProcessingText') === false
+) {
+    $testPassed = false;
+    $errors[] = "Pay Later Confirm Order should show the OPRC/mower processing message (blockPage/oprcProcessingText), not an empty blockUI.";
+} else {
+    echo "✓ Confirm Order uses OPRC/mower processing overlay messaging\n";
+}
+
 echo "\n";
 if ($testPassed) {
     echo "All tests passed! ✓\n";

--- a/tests/WalletIneligiblePaymentHidingTest.php
+++ b/tests/WalletIneligiblePaymentHidingTest.php
@@ -136,12 +136,14 @@ if (strpos($payLaterJs, 'function hidePaymentMethodContainer()') === false) {
     echo "✓ Pay Later JS has hidePaymentMethodContainer function\n";
 }
 
-// Test 14: Pay Later checks button eligibility and hides when ineligible
-if (strpos($payLaterJs, 'buttonInstance.isEligible') === false || strpos($payLaterJs, "hidePaymentMethodContainer()") === false) {
+// Test 14: Pay Later checks button eligibility; Buttons-only hide keeps Confirm Order radio
+if (strpos($payLaterJs, 'buttonInstance.isEligible') === false
+    || strpos($payLaterJs, 'hidePayLaterButtonOnly') === false
+) {
     $testPassed = false;
-    $errors[] = "Pay Later JS should check eligibility and hide when ineligible";
+    $errors[] = "Pay Later JS should check Buttons eligibility and hide only the button (keep radio for Confirm Order)";
 } else {
-    echo "✓ Pay Later JS checks eligibility and hides when ineligible\n";
+    echo "✓ Pay Later JS checks Buttons eligibility without hiding the radio row\n";
 }
 
 // Test 13: All JS files no longer show "unavailable" text when config fails


### PR DESCRIPTION
﻿## Summary
- After cancel/return, PayPal Buttons often reports Pay Later ineligible; we were hiding the entire payment row. Now only the yellow button is cleared so the radio/Confirm Order path stays available.
- Confirm Order overlay on Redline/mower fell through to bare blockUI (empty gray box). Use blockPage / oprcProcessingText / oprcShowProcessingOverlay.
- Bump Pay Later to 1.1.5.

## Test plan
- [ ] Pay Later Confirm Order shows normal OPRC processing message before redirect
- [ ] Cancel from PayPal and return: Pay Later radio still visible
- [ ] Amount outside limits still hides the whole method
