### PR TITLE
Fix Pay Later yellow button with non-US sandbox buyer-country

### DIFF
--- a/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
+++ b/includes/modules/payment/paypal/PayPalAdvancedCheckout/jquery.paypalac.paylater.js
@@ -685,18 +685,40 @@
         return !!(ns && typeof ns.Buttons === 'function' && ns.FUNDING && ns.FUNDING.PAYLATER);
     }
 
+    function headerScriptAllowsSandboxPayLater(script) {
+        if (!script || !script.src) {
+            return true;
+        }
+
+        // Sandbox Pay Later Buttons eligibility follows buyer-country. Reusing a
+        // header SDK loaded with CA (or any non-US country) makes isEligible()
+        // false even though Confirm Order redirect still works.
+        var match = script.src.match(/[?&]buyer-country=([^&]*)/i);
+        if (!match) {
+            return true;
+        }
+
+        return String(decodeURIComponent(match[1] || '')).toUpperCase() === 'US';
+    }
+
     function findReusablePayLaterNamespace(config) {
         var desiredIntent = normalizeSdkIntent(config && config.intent);
+        var isSandbox = ((config && config.environment) || '') === 'sandbox';
+
+        // Prefer the dedicated Pay Later namespace when present.
+        if (namespaceHasPayLaterButtons(window.paypalacPaylater)) {
+            return window.paypalacPaylater;
+        }
+
         var headerScript = findHeaderPayPalScript();
         var headerIntentMatches = getScriptSdkIntent(headerScript) === desiredIntent;
         var headerNs = window.PayPalSDK || window.paypal;
 
         if (headerIntentMatches && namespaceHasPayLaterButtons(headerNs)) {
+            if (isSandbox && !headerScriptAllowsSandboxPayLater(headerScript)) {
+                return null;
+            }
             return headerNs;
-        }
-
-        if (namespaceHasPayLaterButtons(window.paypalacPaylater)) {
-            return window.paypalacPaylater;
         }
 
         return null;

--- a/includes/modules/payment/paypalac_paylater.php
+++ b/includes/modules/payment/paypalac_paylater.php
@@ -52,7 +52,7 @@ class paypalac_paylater extends base
         return defined('MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE') ? (int)MODULE_PAYMENT_PAYPALAC_PAYLATER_ZONE : 0;
     }
 
-    protected const CURRENT_VERSION = '1.1.5';
+    protected const CURRENT_VERSION = '1.1.6';
     protected const WALLET_SUCCESS_STATUSES = [
         PayPalAdvancedCheckoutApi::STATUS_APPROVED,
         PayPalAdvancedCheckoutApi::STATUS_COMPLETED,

--- a/tests/PayLaterAmountLimitsTest.php
+++ b/tests/PayLaterAmountLimitsTest.php
@@ -18,11 +18,11 @@ $langPhp = file_get_contents(__DIR__ . '/../includes/languages/english/modules/p
 fwrite(STDOUT, "Testing Pay Later amount limits\n");
 fwrite(STDOUT, "================================\n\n");
 
-if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.5'") === false) {
-    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.5 after cancel-hide/overlay fix\n");
+if (strpos($paylaterPhp, "protected const CURRENT_VERSION = '1.1.6'") === false) {
+    fwrite(STDERR, "FAIL: paypalac_paylater version should be 1.1.6 after Pay Later Buttons buyer-country fix\n");
     $failures++;
 } else {
-    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.5\n");
+    fwrite(STDOUT, "  ✓ Pay Later module version is 1.1.6\n");
 }
 
 foreach ([
@@ -132,6 +132,15 @@ if (strpos($paylaterJs, 'findReusablePayLaterNamespace') === false
     $failures++;
 } else {
     fwrite(STDOUT, "  ✓ Pay Later JS reuses the header SDK and matches intent\n");
+}
+
+if (strpos($paylaterJs, 'headerScriptAllowsSandboxPayLater') === false
+    || strpos($paylaterJs, 'buyer-country=US') === false
+) {
+    fwrite(STDERR, "FAIL: Pay Later JS must not reuse a non-US sandbox header SDK (Buttons would be ineligible)\n");
+    $failures++;
+} else {
+    fwrite(STDOUT, "  ✓ Pay Later JS skips non-US sandbox header SDK reuse for Buttons eligibility\n");
 }
 
 if ($failures > 0) {


### PR DESCRIPTION
﻿## Summary
- Sandbox header SDK often loads with buyer-country=CA (VPN). Reusing that namespace made Pay Later Buttons isEligible() false, so the yellow button never rendered.
- Skip header reuse when sandbox buyer-country is not US; load dedicated paypalacPaylater SDK with buyer-country=US.
- Bump Pay Later to 1.1.6.

## Test plan
- [ ] Hard-refresh checkout on VPN: yellow Pay Later button appears next to radio
- [ ] Confirm Order still redirects with fundingSource=paylater
- [ ] Cancel/return: radio and yellow button both present
